### PR TITLE
Fix UnitNormMap transformation of the centre

### DIFF
--- a/ast_tester/testunitnormmap.f
+++ b/ast_tester/testunitnormmap.f
@@ -35,6 +35,9 @@
          call checkroundtrip( map, frompos, good, status )
          if( .not. good )  call stopit( status, 'Error 6' )
 
+         call checkroundtrip( map, centre, good, status )
+         if( .not. good )  call stopit( status, 'Error 6' )
+
          invmap = ast_copy( map, status )
          call ast_invert( invmap, status )
          cmpmap = ast_cmpmap( map, invmap, .true., ' ', status )


### PR DESCRIPTION
Modify UnitNormMap to transform the centre properly, and in a way that round trips:
- In the forward direction transform centre to [AST__BAD, ..., AST__BAD, 0]
  (since the components of the unit vector are unknown, but the norm is 0)
- In the inverse direction transform [any_value, ..., any_value, 0] to [0, ..., 0]

Formerly UnitNormMap transform input = centre to [AST__BAD, ..., AST__BAD],
which was incorrect and did not round trip.