### PR TITLE
cmpmap: Avoid MapSplit loop with astDoNotSimplify

### DIFF
--- a/src/cmpmap.c
+++ b/src/cmpmap.c
@@ -2541,8 +2541,16 @@ static int *MapSplit0( AstMapping *this_mapping, int nin, const int *in,
       (void) astMapList( this_mapping, this->series, astGetInvert( this ),
                          &nmap, &map_list, &invert_list );
 
+/* If astMapList was unable to decompose the CmpMap (e.g. if astDoNotSimplify
+   returned true) then the parent class may have returned a list containing
+   just a clone of this CmpMap itself.  When this happens we should not
+   proceed because MapSplit1 will call astMapSplit on this object,
+   causing an infinite loop. */
+      if( nmap == 1 && map_list[0] == this_mapping ) {
+         /* (do nothing) */
+
 /* First handle lists of Mapping in series. */
-      if( this->series ) {
+      } else if( this->series ) {
 
 /* Initialise the array of inputs to be split from the next component
    Mapping. */


### PR DESCRIPTION
It was found that files with WCS including `CmpMap` objects with an `Ident` attribute could cause Starlink applications (such as display) to crash by going into an infinite loop from `astMapSplit`.  Another commit was made elsewhere such that the application in question (SMURF fts2opcorr) should no longer leave `Ident` attributes in the WCS.  Meanwhile this commit is a potential way to prevent a crash inside AST in this case.

When there is a `CmpMap` with an `Ident` attribute, `astDoNotSimplify` returns true and `astMapList` can return the original `CmpMap` itself.  Then `MapSplit0` entered an infinite loop (via `MapSplit1` and `astMapSplit`).

This commit aims to detect when this is happening and prevent the loop.  It seems to work but I'm not sure if this was the best level at which to address the problem.