### PR TITLE
fitschan: Prevent failure when reading FITS-CLASS headers

### DIFF
--- a/ast_tester/ast_tester
+++ b/ast_tester/ast_tester
@@ -177,7 +177,8 @@ foreach n ( "timj ast fits-wcs cdmatrix=1" \
             "sip head fits-wcs cdmatrix=1,sipreplace=0" \
             "sip2 head fits-wcs cdmatrix=1,sipreplace=0" \
             "lsst ast fits-wcs cdmatrix=1" \
-            "longslit fits-pc fits-wcs cdmatrix=1" )
+            "longslit fits-pc fits-wcs cdmatrix=1" \
+            "jan fits-class ast" )
 
   set a = `echo $n`
 

--- a/ast_tester/jan.ast
+++ b/ast_tester/jan.ast
@@ -1,0 +1,193 @@
+ Begin FrameSet 	# Set of inter-related coordinate systems
+#   Title = "3-d compound coordinate system" 	# Title of coordinate system
+#   Naxes = 3 	# Number of coordinate axes
+#   Domain = "SKY-DSBSPECTRUM" 	# Coordinate system domain
+#   Epoch = 2006.8632690742859 	# Julian epoch of observation
+#   Lbl1 = "Right ascension" 	# Label for axis 1
+#   Lbl2 = "Declination" 	# Label for axis 2
+#   Lbl3 = "Frequency (USB)" 	# Label for axis 3
+#   System = "Compound" 	# Coordinate system type
+#   Uni1 = "hh:mm:ss.s" 	# Units for axis 1
+#   Uni2 = "ddd:mm:ss" 	# Units for axis 2
+#   Uni3 = "Hz" 	# Units for axis 3 (Hertz)
+#   Dir1 = 0 	# Plot axis 1 in reverse direction
+ IsA Frame 	# Coordinate system description
+    Nframe = 2 	# Number of Frames in FrameSet
+    Base = 1 	# Index of base Frame
+    Currnt = 2 	# Index of current Frame
+    Lnk2 = 1 	# Node 2 is derived from node 1
+    Frm1 = 	# Frame number 1
+       Begin Frame 	# Coordinate system description
+          Title = "Pixel Coordinates" 	# Title of coordinate system
+          Naxes = 3 	# Number of coordinate axes
+          Domain = "GRID" 	# Coordinate system domain
+#         Lbl1 = "Pixel axis 1" 	# Label for axis 1
+#         Lbl2 = "Pixel axis 2" 	# Label for axis 2
+#         Lbl3 = "Pixel axis 3" 	# Label for axis 3
+          Ax1 = 	# Axis number 1
+             Begin Axis 	# Coordinate axis
+                Label = "Pixel axis 1" 	# Axis Label
+             End Axis
+          Ax2 = 	# Axis number 2
+             Begin Axis 	# Coordinate axis
+                Label = "Pixel axis 2" 	# Axis Label
+             End Axis
+          Ax3 = 	# Axis number 3
+             Begin Axis 	# Coordinate axis
+                Label = "Pixel axis 3" 	# Axis Label
+             End Axis
+       End Frame
+    Frm2 = 	# Frame number 2
+       Begin CmpFrame 	# Compound coordinate system description
+          Ident = " " 	# Permanent Object identification string
+       IsA Object 	# AST Object
+#         Title = "3-d compound coordinate system" 	# Title of coordinate system
+#         Naxes = 3 	# Number of coordinate axes
+#         Domain = "SKY-DSBSPECTRUM" 	# Coordinate system domain
+#         Lbl1 = "Right ascension" 	# Label for axis 1
+#         Lbl2 = "Declination" 	# Label for axis 2
+#         Lbl3 = "Frequency (USB)" 	# Label for axis 3
+#         Uni1 = "hh:mm:ss.s" 	# Units for axis 1
+#         Uni2 = "ddd:mm:ss" 	# Units for axis 2
+#         Uni3 = "Hz" 	# Units for axis 3 (Hertz)
+#         Dir1 = 0 	# Plot axis 1 in reverse direction
+       IsA Frame 	# Coordinate system description
+          FrameA = 	# First component Frame
+             Begin SkyFrame 	# Description of celestial coordinate system
+                Naxes = 2 	# Number of coordinate axes
+                Epoch = 2006.8632690742859 	# Julian epoch of observation
+                System = "FK5" 	# Coordinate system type
+                Ax1 = 	# Axis number 1
+                   Begin SkyAxis 	# Celestial coordinate axis
+                   End SkyAxis
+                Ax2 = 	# Axis number 2
+                   Begin SkyAxis 	# Celestial coordinate axis
+                   End SkyAxis
+             IsA Frame 	# Coordinate system description
+                Proj = "gnomonic" 	# Description of sky projection
+                Eqnox = 2000 	# Julian epoch of mean equinox
+                SRefIs = "Ignored" 	# Not rotated (ref. pos. is ignored)
+                SRef1 = 0.71100769282139487 	# Ref. pos. RA 2:42:57.1
+                SRef2 = 1.0983843929661621 	# Ref. pos. Dec 62:55:58
+             End SkyFrame
+          FrameB = 	# Second component Frame
+             Begin DSBSpecFrame 	# Dual sideband spectral axis
+                Naxes = 1 	# Number of coordinate axes
+                Epoch = 2006.8632690742859 	# Julian epoch of observation
+                System = "FREQ" 	# Coordinate system type
+                Ax1 = 	# Axis number 1
+                   Begin Axis 	# Coordinate axis
+                      Unit = "Hz" 	# Axis units (Hertz)
+                   End Axis
+             IsA Frame 	# Coordinate system description
+                SoR = "Source" 	# Standard of rest
+                RefRA = 0.71100769282139487 	# Reference RA (rads, FK5 J2000)
+                RefDec = 1.0983843929661621 	# Reference Dec (rads, FK5 J2000)
+                RstFrq = 220398676500 	# Rest frequency (Hz)
+                SrcVel = -79989.315688607065 	# Source velocity (m/s)
+                SrcVRF = "LSRK" 	# Source velocity rest frame
+                UFreq = "Hz" 	# Preferred units for frequency
+             IsA SpecFrame 	# Description of spectral coordinate system
+                DSBCen = 220463127593.87817 	# Central frequency (Hz topo)
+                IF = -3999979572.8960571 	# Intermediate frequency (Hz)
+                SideBn = "USB" 	# Represents upper sideband
+             End DSBSpecFrame
+       End CmpFrame
+    Map2 = 	# Mapping between nodes 1 and 2
+       Begin CmpMap 	# Compound Mapping
+          Nin = 3 	# Number of input coordinates
+          IsSimp = 1 	# Mapping has been simplified
+       IsA Mapping 	# Mapping between coordinate systems
+          MapA = 	# First component Mapping
+             Begin WinMap 	# Map one window on to another
+                Nin = 3 	# Number of input coordinates
+             IsA Mapping 	# Mapping between coordinate systems
+                Sft1 = 0.00017453292519943296 	# Shift for axis 1
+                Scl1 = -0.00017453292519943296 	# Scale factor for axis 1
+                Sft2 = -0.00017453292519943296 	# Shift for axis 2
+                Scl2 = 0.00017453292519943296 	# Scale factor for axis 2
+                Sft3 = 125000507.60970327 	# Shift for axis 3
+                Scl3 = -30510.253260850201 	# Scale factor for axis 3
+             End WinMap
+          MapB = 	# Second component Mapping
+             Begin CmpMap 	# Compound Mapping
+                Nin = 3 	# Number of input coordinates
+             IsA Mapping 	# Mapping between coordinate systems
+                InvA = 1 	# First Mapping used in inverse direction
+                MapA = 	# First component Mapping
+                   Begin WcsMap 	# FITS-WCS sky projection
+                      Nin = 3 	# Number of input coordinates
+                      Invert = 1 	# Mapping inverted
+                   IsA Mapping 	# Mapping between coordinate systems
+                      Type = "TAN" 	# Gnomonic projection
+                   End WcsMap
+                MapB = 	# Second component Mapping
+                   Begin CmpMap 	# Compound Mapping
+                      Nin = 3 	# Number of input coordinates
+                   IsA Mapping 	# Mapping between coordinate systems
+                      Series = 0 	# Component Mappings applied in parallel
+                      MapA = 	# First component Mapping
+                         Begin CmpMap 	# Compound Mapping
+                            Nin = 2 	# Number of input coordinates
+                            IsSimp = 1 	# Mapping has been simplified
+                         IsA Mapping 	# Mapping between coordinate systems
+                            InvA = 1 	# First Mapping used in inverse direction
+                            MapA = 	# First component Mapping
+                               Begin SphMap 	# Cartesian to Spherical mapping
+                                  Nin = 3 	# Number of input coordinates
+                                  Nout = 2 	# Number of output coordinates
+                                  Invert = 1 	# Mapping inverted
+                               IsA Mapping 	# Mapping between coordinate systems
+                                  UntRd = 1 	# All input vectors have unit length
+                                  PlrLg = 0 	# Polar longitude (rad.s)
+                               End SphMap
+                            MapB = 	# Second component Mapping
+                               Begin CmpMap 	# Compound Mapping
+                                  Nin = 3 	# Number of input coordinates
+                                  Nout = 2 	# Number of output coordinates
+                               IsA Mapping 	# Mapping between coordinate systems
+                                  MapA = 	# First component Mapping
+                                     Begin MatrixMap 	# Matrix transformation
+                                        Nin = 3 	# Number of input coordinates
+                                     IsA Mapping 	# Mapping between coordinate systems
+                                        M0 = 0.6747158023815587 	# Forward matrix value
+                                        M1 = -0.65259763576007279 	# Forward matrix value
+                                        M2 = 0.34478241227906753 	# Forward matrix value
+                                        M3 = 0.58112081217619194 	# Forward matrix value
+                                        M4 = 0.75770464285258499 	# Forward matrix value
+                                        M5 = 0.29695500644932671 	# Forward matrix value
+                                        M6 = -0.45503536969371128 	# Forward matrix value
+                                        M7 = 0 	# Forward matrix value
+                                        M8 = 0.89047336418767031 	# Forward matrix value
+                                        IM0 = 0.6747158023815587 	# Inverse matrix value
+                                        IM1 = 0.58112081217619194 	# Inverse matrix value
+                                        IM2 = -0.45503536969371128 	# Inverse matrix value
+                                        IM3 = -0.65259763576007279 	# Inverse matrix value
+                                        IM4 = 0.75770464285258499 	# Inverse matrix value
+                                        IM5 = 0 	# Inverse matrix value
+                                        IM6 = 0.34478241227906753 	# Inverse matrix value
+                                        IM7 = 0.29695500644932671 	# Inverse matrix value
+                                        IM8 = 0.89047336418767031 	# Inverse matrix value
+                                        Form = "Full" 	# Matrix storage form
+                                     End MatrixMap
+                                  MapB = 	# Second component Mapping
+                                     Begin SphMap 	# Cartesian to Spherical mapping
+                                        Nin = 3 	# Number of input coordinates
+                                        Nout = 2 	# Number of output coordinates
+                                     IsA Mapping 	# Mapping between coordinate systems
+                                        UntRd = 1 	# All input vectors have unit length
+                                        PlrLg = 0.71100769282139487 	# Polar longitude (rad.s)
+                                     End SphMap
+                               End CmpMap
+                         End CmpMap
+                      MapB = 	# Second component Mapping
+                         Begin ShiftMap 	# Shift each coordinate axis
+                            Nin = 1 	# Number of input coordinates
+                            IsSimp = 1 	# Mapping has been simplified
+                         IsA Mapping 	# Mapping between coordinate systems
+                            Sft1 = 220398648224.8721 	# Shift for axis 1
+                         End ShiftMap
+                   End CmpMap
+             End CmpMap
+       End CmpMap
+ End FrameSet

--- a/ast_tester/jan.fits-class
+++ b/ast_tester/jan.fits-class
@@ -1,0 +1,78 @@
+OBJECT  = 'WB437   '           / Object of interest
+STANDARD=            F / True if the spectral line is a standard
+OBSNUM  =           31 / obs number
+NSUBSCAN=            1 / Sub-scan number
+OBSEND  =            T / True if file is last in current observation
+UTDATE  =         20061112 / UT Date as integer in yyyymmdd format
+DATE-OBS= '2006-11-12T07:23:54.956' / Date of observation
+CRPIX1  =          1.0 / Reference pixel on axis 1
+CRPIX2  =          1.0 / Reference pixel on axis 2
+CRPIX3  =       4097.0 / Reference pixel on axis 3
+CRVAL1  =         40.73774 / Value at ref. pixel on axis 1
+CRVAL2  =         62.93279 / Value at ref. pixel on axis 2
+CRVAL3  =    -28275.1278991699 / Value at ref. pixel on axis 3
+CTYPE1  = 'RA---TAN'           / Type of co-ordinate on axis 1
+CTYPE2  = 'DEC--TAN'           / Type of co-ordinate on axis 2
+CTYPE3  = 'FREQ    '           / Type of co-ordinate on axis 3
+CDELT1  =        -0.01 / Pixel size
+CDELT2  =         0.01 / Pixel size
+CDELT3  =    -30510.2532608502 / Pixel size
+EQUINOX =       2000.0 / Epoch of reference equinox
+RESTFREQ=   220398676500.0 / [Hz] Rest frequency
+IMAGFREQ=     212401000570.803 / [Hz] Image frequency
+LINE    = '    '
+VELO-LSR=    -79961.5291150086 / [m/s] Reference velocity
+VLSR    =    -79961.5291150086 / [m/s] Reference velocity
+DELTAV  =     41.5119762584945 / [m/s] Velocity resolution
+AZIMUTH =     19.7339944679958 / [Deg] Telescope azimuth
+ELEVATIO=     41.0106531289803 / [Deg] Telescope elevation
+DATE-END= '2006-11-12T08:58:15' / UTC Datetime of end of observation
+OBSID   = 'acsis_31_20061112T084334' / Unique observation identifier
+E-TOCLASS,  Error decoding OBSID
+INSTAP  = 'A       '           / Receptor at tracking centre (if any)
+INSTAP_X=          0.0 / [arcsec] Aperture X off. rel. to instr cent
+INSTAP_Y=          0.0 / [arcsec] Aperture Y off. rel. to instr cent
+AMSTART =   1.397363700778 / Airmass at start of obervation
+AMEND   =   1.384634790086 / Airmass at end of obervation
+AZSTART =   369.4312720735 / [deg] Azimuth at obs. start - mount sys.
+AZEND   =   366.9034439805 / [deg] Azimuth at obs. end - mount sys.
+ELSTART =   45.70770101123 / [deg] Elevation at obs. start - mount
+sys.
+ELEND   =   46.24950299273 / [deg] Elevation at obs. end - mount sys.
+HSTSTART= '2006-11-11T22:43:34' / HST at start of observation
+HSTEND  = '2006-11-11T22:58:15' / HST at end of observation
+LSTSTART= '01:47:01.8620'      / LST at start of observation
+LSTEND  = '02:01:45.3333'
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/fitschan.c
+++ b/src/fitschan.c
@@ -1282,6 +1282,10 @@ f     - AST_WRITEFITS: Write all cards out to the sink function
 *     8-APR-2026 (TIMJ):
 *        Use larger bounded buffers in a few internal formatting paths and
 *        guard Match against zero returned fields when reversing them.
+*     22-APR-2026 (DSB):
+*        In SpecTrans, only attempt to convert CLASS specific keywords
+*        into standard FITS-WCS keywords for the primary axis descriptions
+*        since CLASS does not support alternate axis descriptions.
 *class--
 */
 
@@ -31577,7 +31581,7 @@ static AstFitsChan *SpecTrans( AstFitsChan *this, int encoding,
 
 /* Things specific to the CLASS encoding
    ------------------------------------- */
-      if( encoding == FITSCLASS_ENCODING ) ClassTrans( this, ret, axlat,
+      if( s == ' ' && encoding == FITSCLASS_ENCODING ) ClassTrans( this, ret, axlat,
                                                        axlon, method, class, status );
 
 /* Convert SAO distorted TAN headers to TPN distorted TAN headers.


### PR DESCRIPTION
FITS-CLASS headers are only defined for the primary axis descriptions. Attempting to read them for alternate axis descriptions was causing an error. This PR contains a fix for this bug plus an extra wcs conversion test.