### PR TITLE
ast_tester: add new utility function to help configure plplot

### DIFF
--- a/ast_tester/CMakeLists.txt
+++ b/ast_tester/CMakeLists.txt
@@ -3,6 +3,7 @@
 # These are the existing C test programs, plus Fortran tests that have
 # been converted to C.  All tests use CTest and do not require any
 # Starlink infrastructure.
+include(CheckCSourceRuns)
 
 # Ensure test executables find the locally-built libast before any
 # system-installed version (e.g. from a conda environment whose lib
@@ -465,8 +466,37 @@ foreach(_entry IN LISTS _grid_tests)
 endforeach()
 
 if(PLPLOT_FOUND)
+    # --- Determine if pdfcairo is available ---
+    # If not, plplot falls back on the "pdf" device which uses libHaru, which
+    # fails with some of the pdf tests; if the pdfcairo device is not availble
+    # then we just mark these tests as expected failures.
+
+    check_c_source_runs("
+    #include <string.h>
+    #include <plplot.h>
+    #include \"ast.h\"
+
+    int main(void) {
+        const char *dev = astPlSetupDevice(\"test.pdf\");
+        if (dev && strcmp(dev, \"pdfcairo\") == 0) {
+            return 0;
+        } else {
+            return 1;
+        }
+    }
+    " HAVE_PLPLOT_PDFCAIRO)
+
+    # Plotter tests that are known to fail without pdfcairo
+    set(PLOTTER_XFAIL_NO_PDFCAIRO
+        car4
+        car6
+        specflux
+        timeplot
+    )
+
     configure_file(lsst.fits-wcs "${CMAKE_CURRENT_BINARY_DIR}/lsst.fits-wcs" COPYONLY)
     ast_add_test(testplotter
+        SOURCES testplotter.c plplotutil.c
         NO_DEFAULT_GRF_LIBS
         EXTRA_LIBS $<LINK_LIBRARY:WHOLE_ARCHIVE,ast_grf_plplot> $<LINK_LIBRARY:WHOLE_ARCHIVE,ast_grf3d_plplot> ${PLPLOT_LIBRARIES}
         TEST_ARGS "lsst.fits-wcs" " " " " "testplotter.ps"
@@ -476,6 +506,7 @@ if(PLPLOT_FOUND)
 
     configure_file(plot3d-test1.ast "${CMAKE_CURRENT_BINARY_DIR}/plot3d-test1.ast" COPYONLY)
     ast_add_test(testplot3d
+        SOURCES testplot3d.c plplotutil.c
         NO_DEFAULT_GRF_LIBS
         EXTRA_LIBS $<LINK_LIBRARY:WHOLE_ARCHIVE,ast_grf_plplot> $<LINK_LIBRARY:WHOLE_ARCHIVE,ast_grf3d_plplot> ${PLPLOT_LIBRARIES}
         TEST_ARGS "testplot3d.pdf"
@@ -520,9 +551,20 @@ if(PLPLOT_FOUND)
                 "-DBOX=${_box_arg}"
                 -P "${CMAKE_SOURCE_DIR}/cmake/run_plotter_test.cmake"
             WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+
         if(AST_ENABLE_SANITIZERS)
             set_tests_properties(plotter_${P_NAME} PROPERTIES
                 ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+        endif()
+
+        # Mark test as expected failure if it's one known not to work
+        # without pdfcairo
+        if(NOT HAVE_PLPLOT_PDFCAIRO)
+            list(FIND PLOTTER_XFAIL_NO_PDFCAIRO "${P_NAME}" _idx)
+            if(NOT _idx EQUAL -1)
+                set_tests_properties(plotter_${P_NAME} PROPERTIES
+                    WILL_FAIL TRUE)
+            endif()
         endif()
     endfunction()
 
@@ -546,6 +588,5 @@ if(PLPLOT_FOUND)
         endif()
         add_plotter_test(${_args})
     endforeach()
-
 endif()
 

--- a/ast_tester/CMakeLists.txt
+++ b/ast_tester/CMakeLists.txt
@@ -471,20 +471,31 @@ if(PLPLOT_FOUND)
     # fails with some of the pdf tests; if the pdfcairo device is not availble
     # then we just mark these tests as expected failures.
 
+    set(_old_includes "${CMAKE_REQUIRED_INCLUDES}")
+    set(_old_libs "${CMAKE_REQUIRED_LIBRARIES}")
+    set(CMAKE_REQUIRED_INCLUDES ${PLPLOT_INCLUDE_DIRS})
+    set(CMAKE_REQUIRED_LIBRARIES ${PLPLOT_LIBRARIES})
     check_c_source_runs("
     #include <string.h>
     #include <plplot.h>
-    #include \"ast.h\"
 
     int main(void) {
-        const char *dev = astPlSetupDevice(\"test.pdf\");
-        if (dev && strcmp(dev, \"pdfcairo\") == 0) {
-            return 0;
-        } else {
-            return 1;
+        const char *menustr[32];
+        const char *devnames[32];
+        const char **pmenustr = menustr;
+        const char **pdevnames = devnames;
+        int idx;
+        int pl_ndev = 32;
+        plgDevs(&pmenustr, &pdevnames, &pl_ndev);
+        for (idx = 0; idx < pl_ndev; idx++) {
+            if (devnames[idx] && strcmp(devnames[idx], \"pdfcairo\") == 0)
+                return 0;
         }
+        return 1;
     }
     " HAVE_PLPLOT_PDFCAIRO)
+    set(CMAKE_REQUIRED_INCLUDES ${_old_includes})
+    set(CMAKE_REQUIRED_LIBRARIES ${_old_libs})
 
     # Plotter tests that are known to fail without pdfcairo
     set(PLOTTER_XFAIL_NO_PDFCAIRO

--- a/ast_tester/CMakeLists.txt
+++ b/ast_tester/CMakeLists.txt
@@ -471,10 +471,9 @@ if(PLPLOT_FOUND)
     # fails with some of the pdf tests; if the pdfcairo device is not availble
     # then we just mark these tests as expected failures.
 
-    set(_old_includes "${CMAKE_REQUIRED_INCLUDES}")
-    set(_old_libs "${CMAKE_REQUIRED_LIBRARIES}")
     set(CMAKE_REQUIRED_INCLUDES ${PLPLOT_INCLUDE_DIRS})
     set(CMAKE_REQUIRED_LIBRARIES ${PLPLOT_LIBRARIES})
+    set(CMAKE_REQUIRED_LINK_DIRECTORIES ${PLPLOT_LIBRARY_DIRS})
     check_c_source_runs("
     #include <string.h>
     #include <plplot.h>
@@ -494,8 +493,9 @@ if(PLPLOT_FOUND)
         return 1;
     }
     " HAVE_PLPLOT_PDFCAIRO)
-    set(CMAKE_REQUIRED_INCLUDES ${_old_includes})
-    set(CMAKE_REQUIRED_LIBRARIES ${_old_libs})
+    unset(CMAKE_REQUIRED_INCLUDES)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+    unset(CMAKE_REQUIRED_LINK_DIRECTORIES)
 
     # Plotter tests that are known to fail without pdfcairo
     set(PLOTTER_XFAIL_NO_PDFCAIRO

--- a/ast_tester/plplotutil.c
+++ b/ast_tester/plplotutil.c
@@ -138,6 +138,14 @@ void astPlSetupDevice( const char *output ) {
    const char *ext;
    const char *dev;
 
+   /* Fallback in case output is null: render to null device (always
+    * available) */
+   if ( !output ) {
+      c_plsdev( "null" );
+      return;
+   }
+
+   /* Check for possible interactive outputs (useful for manual testing) */
    if( strcmp(output, "aqt") == 0 || strcmp(output, "xwin") == 0 ||
        strcmp(output, "xcairo") == 0 || strcmp(output, "qtwidget") == 0 ) {
 
@@ -152,12 +160,13 @@ void astPlSetupDevice( const char *output ) {
       }
    }
 
+   /* Choose best output device from filename extension */
    ext = strrchr( output, '.' );
    dev = astPlChooseDeviceForExtension( ext );
 
    if ( !astPlDeviceAvailable( dev ) ) {
       fprintf( stderr, "plplot output device %s for %s files not "
-               "available; falling back on null device\n", ext, output );
+               "available; falling back on null device\n", dev, ext );
       dev = "null";
    }
 

--- a/ast_tester/plplotutil.c
+++ b/ast_tester/plplotutil.c
@@ -1,0 +1,166 @@
+/*
+*  Name:
+*     plplotutil.c
+*
+*  Purpose:
+*     Common utilities for configuring tests that use PLplot.
+*
+*  Description:
+*     The main interface exported by this module is astPlDeviceSetup( output ).
+*     This encapuslates the logic for selecting the best availble PLplot
+*     output device either for interactive plotting or for a given filename
+*     extension.
+*
+*  Usage:
+*     Call astPlDeviceSetup( output ) before calling c_plinit()
+*
+*     Output is optional. It can be:
+*     - A file ending in ".pdf": generates a PDF file (pdfcairo with fallback
+*       to the generic pdf device, or psc).
+*     - A file ending in ".png": generates a PNG file (pngcairo with fallback
+*       to the generic png device).
+*     - A file ending in ".svg": generates an SVG file (svgcairo with fallback
+*       to the generic svg device).
+*     - "aqt", "xwin", "xcairo", "qtwidget": interactive window.
+*     - Any other name: PostScript (psc device).
+*     - If all else fails outputs to the "null" device.
+*     - Omitted: defaults to "testplot3d.pdf".
+*/
+
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <plplot.h>
+
+
+/* Maximum number of PLplot devices to support; 64 is more than enough */
+#define AST_PLPLOT_MAX_DEV 64
+
+
+/* Globals for selecting the best plplot device based on availability */
+static const char *pl_devnames[AST_PLPLOT_MAX_DEV] = {0};
+
+/* Number of available plplot devices
+ *
+ * Defaults to 64 which sets the max allowed to probe with plgDevs();
+ * this in turn sets the actual number of devices found */
+static int pl_ndev = AST_PLPLOT_MAX_DEV;
+
+
+/* Initialize global array of available plplot devices */
+static void astPlInitDeviceList( void ) {
+   const char **menustr;
+   const char **devnames = pl_devnames;
+
+   if (devnames[0]) /* Should have at least one entry */
+      return;
+
+   menustr = calloc(pl_ndev, sizeof(*menustr));
+
+   if ( !menustr )
+      return;
+
+   /* Not-well advertised but available API for probing supported devices */
+   plgDevs(&menustr, &devnames, &pl_ndev);
+   free( menustr );
+}
+
+
+/* Probe available device list for support */
+static int astPlDeviceAvailable( const char *dev ) {
+   int idx;
+
+   astPlInitDeviceList();
+
+   for (idx = 0; idx < pl_ndev; idx++) {
+      if (strcmp(pl_devnames[idx], dev) == 0)
+         return 1;
+   }
+
+   return 0;
+}
+
+
+/* Depending on the output filename choose the best available plplot device */
+static const char *astPlChooseDeviceForExtension( const char *ext ) {
+   int idx;
+
+   if (!ext)
+      return "psc";
+
+   if (strcmp(ext, ".pdf") == 0) {
+      const char *candidates[] = {
+         "pdfcairo", // best
+         "pdf",      // generic but widely supported
+         "psc",      // last resort
+         NULL
+      };
+
+      for (idx = 0; candidates[idx]; idx++) {
+         if (astPlDeviceAvailable( candidates[ idx ] ))
+            return candidates[ idx ];
+      }
+   }
+
+   if (strcmp(ext, ".png") == 0) {
+      const char *candidates[] = {
+         "pngcairo",
+         "png",
+         NULL
+      };
+
+      for (idx = 0; candidates[idx]; idx++) {
+         if (astPlDeviceAvailable( candidates[ idx ] ))
+            return candidates[ idx ];
+      }
+   }
+
+   if (strcmp(ext, ".svg") == 0) {
+      const char *candidates[] = {
+         "svgcairo",
+         "svg",
+         NULL
+      };
+
+      for (idx = 0; candidates[idx]; idx++) {
+         if (astPlDeviceAvailable( candidates[ idx ] ))
+            return candidates[ idx ];
+      }
+   }
+
+   return "psc";
+}
+
+
+/* Setup PLplot output device based on filename or device name */
+void astPlSetupDevice( const char *output ) {
+   const char *ext;
+   const char *dev;
+
+   if( strcmp(output, "aqt") == 0 || strcmp(output, "xwin") == 0 ||
+       strcmp(output, "xcairo") == 0 || strcmp(output, "qtwidget") == 0 ) {
+
+      if (astPlDeviceAvailable( output )) {
+         c_plsdev( output );
+         return;
+      } else {
+         fprintf( stderr, "Selected plplot output device %s not available; "
+                  "falling back on null device\n", output );
+         c_plsdev( "null" );
+         return;
+      }
+   }
+
+   ext = strrchr( output, '.' );
+   dev = astPlChooseDeviceForExtension( ext );
+
+   if ( !astPlDeviceAvailable( dev ) ) {
+      fprintf( stderr, "plplot output device %s for %s files not "
+               "available; falling back on null device\n", ext, output );
+      dev = "null";
+   }
+
+   c_plsdev( dev );
+   c_plsfnam( output );
+}

--- a/ast_tester/plplotutil.c
+++ b/ast_tester/plplotutil.c
@@ -28,10 +28,11 @@
 */
 
 
-#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <plplot.h>
+
+#include "ast.h"
 
 
 /* Maximum number of PLplot devices to support; 64 is more than enough */
@@ -56,14 +57,14 @@ static void astPlInitDeviceList( void ) {
    if (devnames[0]) /* Should have at least one entry */
       return;
 
-   menustr = calloc(pl_ndev, sizeof(*menustr));
+   menustr = astMalloc( pl_ndev * sizeof(*menustr) );
 
    if ( !menustr )
       return;
 
    /* Not-well advertised but available API for probing supported devices */
-   plgDevs(&menustr, &devnames, &pl_ndev);
-   free( menustr );
+   plgDevs( &menustr, &devnames, &pl_ndev );
+   astFree( menustr );
 }
 
 
@@ -74,7 +75,7 @@ static int astPlDeviceAvailable( const char *dev ) {
    astPlInitDeviceList();
 
    for (idx = 0; idx < pl_ndev; idx++) {
-      if (strcmp(pl_devnames[idx], dev) == 0)
+      if ( strcmp( pl_devnames[idx], dev ) == 0 )
          return 1;
    }
 
@@ -86,10 +87,10 @@ static int astPlDeviceAvailable( const char *dev ) {
 static const char *astPlChooseDeviceForExtension( const char *ext ) {
    int idx;
 
-   if (!ext)
+   if ( !ext )
       return "psc";
 
-   if (strcmp(ext, ".pdf") == 0) {
+   if ( strcmp( ext, ".pdf" ) == 0 ) {
       const char *candidates[] = {
          "pdfcairo", // best
          "pdf",      // generic but widely supported
@@ -97,34 +98,34 @@ static const char *astPlChooseDeviceForExtension( const char *ext ) {
          NULL
       };
 
-      for (idx = 0; candidates[idx]; idx++) {
-         if (astPlDeviceAvailable( candidates[ idx ] ))
+      for ( idx = 0; candidates[idx]; idx++ ) {
+         if ( astPlDeviceAvailable( candidates[ idx ] ) )
             return candidates[ idx ];
       }
    }
 
-   if (strcmp(ext, ".png") == 0) {
+   if ( strcmp( ext, ".png" ) == 0 ) {
       const char *candidates[] = {
          "pngcairo",
          "png",
          NULL
       };
 
-      for (idx = 0; candidates[idx]; idx++) {
-         if (astPlDeviceAvailable( candidates[ idx ] ))
+      for ( idx = 0; candidates[idx]; idx++ ) {
+         if ( astPlDeviceAvailable( candidates[ idx ] ) )
             return candidates[ idx ];
       }
    }
 
-   if (strcmp(ext, ".svg") == 0) {
+   if ( strcmp( ext, ".svg" ) == 0 ) {
       const char *candidates[] = {
          "svgcairo",
          "svg",
          NULL
       };
 
-      for (idx = 0; candidates[idx]; idx++) {
-         if (astPlDeviceAvailable( candidates[ idx ] ))
+      for ( idx = 0; candidates[idx]; idx++ ) {
+         if ( astPlDeviceAvailable( candidates[ idx ] ) )
             return candidates[ idx ];
       }
    }
@@ -146,10 +147,10 @@ void astPlSetupDevice( const char *output ) {
    }
 
    /* Check for possible interactive outputs (useful for manual testing) */
-   if( strcmp(output, "aqt") == 0 || strcmp(output, "xwin") == 0 ||
-       strcmp(output, "xcairo") == 0 || strcmp(output, "qtwidget") == 0 ) {
+   if( strcmp( output, "aqt" ) == 0 || strcmp( output, "xwin" ) == 0 ||
+       strcmp( output, "xcairo" ) == 0 || strcmp( output, "qtwidget" ) == 0 ) {
 
-      if (astPlDeviceAvailable( output )) {
+      if ( astPlDeviceAvailable( output ) ) {
          c_plsdev( output );
          return;
       } else {

--- a/ast_tester/plplotutil.h
+++ b/ast_tester/plplotutil.h
@@ -1,0 +1,58 @@
+#if !defined( PLPLOTUTIL_INCLUDED ) /* Include this file only once */
+#define PLPLOTUTIL_INCLUDED
+
+/*
+*+
+*  Name:
+*     plplotutil.h
+
+*  Type:
+*     C include file.
+
+*  Purpose:
+*     Define the interface to the plplotutil.c test utility module.
+
+*  Invocation:
+*     #include "plplotutil.h"
+
+*  Description:
+*     This include file defines the interface to the plplotutil module and
+*     provides the type definitions, function prototypes and macros, etc.
+*     needed to use this module.
+
+*  Inheritance:
+*     The plplotutil module is not a class and does not inherit.
+
+*  Copyright:
+*     Copyright (C) 2026 Council for the Central Laboratory of the
+*     Research Councils
+
+*  Licence:
+*     This program is free software: you can redistribute it and/or
+*     modify it under the terms of the GNU Lesser General Public
+*     License as published by the Free Software Foundation, either
+*     version 3 of the License, or (at your option) any later
+*     version.
+*     
+*     This program is distributed in the hope that it will be useful,
+*     but WITHOUT ANY WARRANTY; without even the implied warranty of
+*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*     GNU Lesser General Public License for more details.
+*     
+*     You should have received a copy of the GNU Lesser General
+*     License along with this program.  If not, see
+*     <http://www.gnu.org/licenses/>.
+
+*  Authors:
+*     EMB: E. Madison Bray (STScI)
+
+*  History:
+*     24-APR-2026 (EMB):
+*        Original version.
+*/
+
+/* Function prototypes. */
+/* ==================== */
+void astPlSetupDevice( const char * );
+
+#endif /* PLPLOTUTIL_INCLUDE */

--- a/ast_tester/testplot3d.c
+++ b/ast_tester/testplot3d.c
@@ -45,6 +45,7 @@
 #include "ast.h"
 #include "ast_err.h"
 #include "pl3d.h"
+#include "plplotutil.h"
 
 static void stopit( int *status, const char *text ) {
    if( *status != 0 ) return;
@@ -142,28 +143,6 @@ static AstObject *readTest( const char *name, int *status ) {
    return result;
 }
 
-/* Setup PLplot output device based on filename or device name */
-static void setupDevice( const char *output ) {
-   const char *ext;
-
-   if( strcmp(output, "aqt") == 0 || strcmp(output, "xwin") == 0 ||
-       strcmp(output, "xcairo") == 0 || strcmp(output, "qtwidget") == 0 ) {
-      c_plsdev( output );
-   } else {
-      ext = strrchr( output, '.' );
-      if( ext && strcmp(ext, ".pdf") == 0 ) {
-         c_plsdev( "pdfcairo" );
-      } else if( ext && strcmp(ext, ".svg") == 0 ) {
-         c_plsdev( "svgcairo" );
-      } else if( ext && strcmp(ext, ".png") == 0 ) {
-         c_plsdev( "pngcairo" );
-      } else {
-         c_plsdev( "psc" );
-      }
-      c_plsfnam( output );
-   }
-}
-
 
 int main( int argc, char **argv ) {
    int status = 0;
@@ -190,7 +169,7 @@ int main( int argc, char **argv ) {
    }
 
    /* Initialize PLplot */
-   setupDevice( output );
+   (void)astPlSetupDevice( output );
    c_plinit();
 
    /* Set up viewport and window. Use a viewport with small margins to

--- a/ast_tester/testplotter.c
+++ b/ast_tester/testplotter.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <plplot.h>
 #include "ast.h"
+#include "plplotutil.h"
 
 int main(int argc, char **argv) {
     int status = 0;
@@ -115,22 +116,7 @@ int main(int argc, char **argv) {
         remove(psfile);
 
         /* Setup PLplot device based on file extension or interactive name */
-        const char *ext = strrchr(psfile, '.');
-        if (strcmp(psfile, "aqt") == 0 || strcmp(psfile, "xwin") == 0 || strcmp(psfile, "xcairo") == 0 || strcmp(psfile, "qtwidget") == 0) {
-            c_plsdev(psfile); /* Interactive window display */
-        } else if (ext && strcmp(ext, ".pdf") == 0) {
-            c_plsdev("pdfcairo");
-            c_plsfnam(psfile);
-        } else if (ext && strcmp(ext, ".svg") == 0) {
-            c_plsdev("svgcairo");
-            c_plsfnam(psfile);
-        } else if (ext && strcmp(ext, ".png") == 0) {
-            c_plsdev("pngcairo");
-            c_plsfnam(psfile);
-        } else {
-            c_plsdev("psc");
-            c_plsfnam(psfile);
-        }
+        (void)astPlSetupDevice( psfile );
 
         /* Initialize PLplot */
         c_plinit();


### PR DESCRIPTION
Side quest I went on while working on test coverage support.

I found that the plotting tests were hanging for me -- even though I had PLplot installed, I did not have the cairo driver for it, and the tests that generate PDFs all default to the pdfcairo driver.

PLplot's default behavior in this case, a bit irritatingly, is to block on a stdin prompt requesting the user to select a driver.

After digging around I found some public functions in the C API that allow probing for supported devices.  At first I just put this support code in the tests, but there was some duplication in both testplot3d.c and testplotter.c, so I thought maybe this could make a useful addition to the public API.

After getting that working, it turned out that some of the plots fail with PLplot's non-cairo PDF backend, libharu.  Understanding why that is at this point is beyond me though, so I added a configure-time check for this and marked the affected tests as expected failures in this case.