### PR TITLE
Add new cmpmap simplify test

### DIFF
--- a/ast_tester/simplify_fixtures/cmpmap_nested_inverse_cancel.map
+++ b/ast_tester/simplify_fixtures/cmpmap_nested_inverse_cancel.map
@@ -1,0 +1,45 @@
+ Begin CmpMap 	# Compound Mapping
+    Nin = 2 	# Number of input coordinates
+ IsA Mapping 	# Mapping between coordinate systems
+    InvB = 1 	# Second Mapping used in inverse direction
+    MapA = 	# First component Mapping
+       Begin CmpMap 	# Compound Mapping
+          Nin = 2 	# Number of input coordinates
+       IsA Mapping 	# Mapping between coordinate systems
+          MapA = 	# First component Mapping
+             Begin MatrixMap 	# Matrix transformation
+                Nin = 2 	# Number of input coordinates
+             IsA Mapping 	# Mapping between coordinate systems
+                M0 = 2 	# Forward matrix value
+                M1 = 3 	# Forward matrix value
+                IM0 = 0.5 	# Inverse matrix value
+                IM1 = 0.33333333333333331 	# Inverse matrix value
+                Form = "Diagonal" 	# Matrix storage form
+             End MatrixMap
+          MapB = 	# Second component Mapping
+             Begin UnitMap 	# Unit (null) Mapping
+                Nin = 2 	# Number of input coordinates
+             IsA Mapping 	# Mapping between coordinate systems
+             End UnitMap
+       End CmpMap
+    MapB = 	# Second component Mapping
+       Begin CmpMap 	# Compound Mapping
+          Nin = 2 	# Number of input coordinates
+       IsA Mapping 	# Mapping between coordinate systems
+          MapA = 	# First component Mapping
+             Begin UnitMap 	# Unit (null) Mapping
+                Nin = 2 	# Number of input coordinates
+             IsA Mapping 	# Mapping between coordinate systems
+             End UnitMap
+          MapB = 	# Second component Mapping
+             Begin MatrixMap 	# Matrix transformation
+                Nin = 2 	# Number of input coordinates
+             IsA Mapping 	# Mapping between coordinate systems
+                M0 = 2 	# Forward matrix value
+                M1 = 3 	# Forward matrix value
+                IM0 = 0.5 	# Inverse matrix value
+                IM1 = 0.33333333333333331 	# Inverse matrix value
+                Form = "Diagonal" 	# Matrix storage form
+             End MatrixMap
+       End CmpMap
+ End CmpMap

--- a/ast_tester/simplify_fixtures/cmpmap_nested_inverse_cancel.simp
+++ b/ast_tester/simplify_fixtures/cmpmap_nested_inverse_cancel.simp
@@ -1,0 +1,5 @@
+ Begin UnitMap 	# Unit (null) Mapping
+    Nin = 2 	# Number of input coordinates
+    IsSimp = 1 	# Mapping has been simplified
+ IsA Mapping 	# Mapping between coordinate systems
+ End UnitMap

--- a/ast_tester/simplify_tests.txt
+++ b/ast_tester/simplify_tests.txt
@@ -31,6 +31,7 @@ shift_invert_normalize  | simplify_fixtures/shift_invert_normalize.map  | simpli
 perm_series_merge       | simplify_fixtures/perm_series_merge.map       | simplify_fixtures/perm_series_merge.simp       |
 perm_parallel_merge     | simplify_fixtures/perm_parallel_merge.map     | simplify_fixtures/perm_parallel_merge.simp     |
 cmpmap_parallel_series_components | simplify_fixtures/cmpmap_parallel_series_components.map | simplify_fixtures/cmpmap_parallel_series_components.simp |
+cmpmap_nested_inverse_cancel | simplify_fixtures/cmpmap_nested_inverse_cancel.map | simplify_fixtures/cmpmap_nested_inverse_cancel.simp |
 cmpmap_nested_parallel_flatten | simplify_fixtures/cmpmap_nested_parallel_flatten.map | simplify_fixtures/cmpmap_nested_parallel_flatten.simp |
 cmpmap_perm_parallel_swap | simplify_fixtures/cmpmap_perm_parallel_swap.map | simplify_fixtures/cmpmap_perm_parallel_swap.simp |
 sph_inverse_cancel      | simplify_fixtures/sph_inverse_cancel.map      | simplify_fixtures/sph_inverse_cancel.simp      |


### PR DESCRIPTION
This one is important for FITS WCS creation.
It takes a MatrixMap UnitMap UnitMap MatrixMap inverse and converts it to a UnitMap.