### PR TITLE
Add grism/ratemap/sph_matrix simplify fixtures

### DIFF
--- a/ast_tester/gen_simplify_fixtures.c
+++ b/ast_tester/gen_simplify_fixtures.c
@@ -19,6 +19,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+static void write_negative_fixture(const char *dir, const char *name, AstMapping *map);
+
 static void write_fixture(const char *dir, const char *name, AstMapping *map) {
     char path_map[512], path_simp[512];
     AstChannel *chan;
@@ -976,6 +978,79 @@ static void gen_pcdmap_fixtures(const char *dir) {
         write_fixture(dir, "pcd_zoom_swap_cancel", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         p1 = astAnnul(p1); zm = astAnnul(zm); p2 = astAnnul(p2);
+    }
+}
+
+/* ===== ChebyMap fixtures =====
+ *
+ * ChebyMap inherits from PolyMap and uses PolyMap's MapMerge, so the
+ * simplification behaviour is the PolyMap rule set plus the ChebyMap-
+ * specific dump format (an extra PolyMap "section" between Mapping and
+ * ChebyMap holding the polynomial coefficients, with FSCL/FOFF emitted
+ * as the ChebyMap-level attributes after `IsA PolyMap`).
+ *
+ * These fixtures exercise:
+ *   - chebymap_inverse_cancel:    forward + inverted twin → UnitMap
+ *   - neg_chebymap_standalone:    bare ChebyMap with no neighbour → no simplify
+ *
+ * The negative fixture is the primary diagnostic for byte-exact dumping:
+ * any drift in the inheritance-section layout (Mapping → PolyMap → ChebyMap)
+ * surfaces on the .map round-trip.
+ */
+
+static void gen_chebymap_fixtures(const char *dir) {
+    printf("ChebyMap fixtures:\n");
+
+    /* chebymap-01: forward ChebyMap followed by its inverted twin → cancel.
+     *
+     * Build a 1D ChebyMap with both forward and inverse Chebyshev
+     * coefficients so the inverse direction is usable; pair it with an
+     * identical-then-inverted twin, in series. PolyMap::MapMerge's
+     * inverse-cancellation rule should collapse the pair to a UnitMap. */
+    {
+        double coeff_f[] = {
+            /* y = 0.5 * T1(x) = 0.5 x  (T1(x) = x in Chebyshev basis) */
+            0.5, 1, 1,
+        };
+        double coeff_i[] = {
+            /* x = 2 * T1(y)  (inverse of y = 0.5 x) */
+            2.0, 1, 1,
+        };
+        double lbnd[] = {-1.0};
+        double ubnd[] = { 1.0};
+        AstChebyMap *c1 = astChebyMap(1, 1, 1, coeff_f, 1, coeff_i,
+                                      lbnd, ubnd, lbnd, ubnd, "");
+        AstChebyMap *c2 = astChebyMap(1, 1, 1, coeff_f, 1, coeff_i,
+                                      lbnd, ubnd, lbnd, ubnd, "");
+        astInvert(c2);
+        AstCmpMap *cm = astCmpMap(c1, c2, 1, "");
+        write_fixture(dir, "chebymap_inverse_cancel", (AstMapping*)cm);
+        cm = astAnnul(cm); c1 = astAnnul(c1); c2 = astAnnul(c2);
+    }
+
+    /* chebymap-02: standalone non-trivial 2D ChebyMap → no simplification.
+     *
+     * Bounds [-2, 2]^2 (non-default), a small set of forward Chebyshev
+     * coefficients, no inverse polynomial. With no neighbour and no
+     * inverse pair to cancel against, astSimplify leaves it unchanged.
+     * The .map and .simp dumps should be identical. */
+    {
+        double coeff_f[] = {
+            /* (coeff, out_axis, px, py) */
+            1.0,  1, 1, 0,
+            0.05, 1, 0, 1,
+            0.02, 1, 2, 0,
+            1.0,  2, 0, 1,
+            0.05, 2, 1, 0,
+            0.02, 2, 0, 2,
+        };
+        double lbnd[] = {-2.0, -2.0};
+        double ubnd[] = { 2.0,  2.0};
+        AstChebyMap *cm = astChebyMap(2, 2, 6, coeff_f, 0, NULL,
+                                       lbnd, ubnd, NULL, NULL, "");
+        write_negative_fixture(dir, "neg_chebymap_standalone",
+                                (AstMapping*)cm);
+        cm = astAnnul(cm);
     }
 }
 
@@ -2994,6 +3069,7 @@ int main(void) {
     gen_wcsmap_fixtures(dir);
     gen_sphmap_fixtures(dir);
     gen_pcdmap_fixtures(dir);
+    gen_chebymap_fixtures(dir);
     gen_switchmap_fixtures(dir);
     gen_tranmap_extra_fixtures(dir);
     gen_matrix_cascade_fixtures(dir);

--- a/ast_tester/gen_simplify_fixtures.c
+++ b/ast_tester/gen_simplify_fixtures.c
@@ -393,6 +393,20 @@ static void gen_ratemap_fixtures(const char *dir) {
         rm = astAnnul(rm); inner = astAnnul(inner);
         z1 = astAnnul(z1); z2 = astAnnul(z2);
     }
+
+    /* ratemap-02: forward RateMap + inverted RateMap (same encapsulated
+       mapping) → cancel via inverse */
+    {
+        AstZoomMap *z1 = astZoomMap(1, 2.0, "");
+        AstZoomMap *z2 = astZoomMap(1, 2.0, "");
+        AstRateMap *r1 = astRateMap(z1, 1, 1, "");
+        AstRateMap *r2 = astRateMap(z2, 1, 1, "");
+        astInvert(r2);
+        AstCmpMap *cm = astCmpMap(r1, r2, 1, "");
+        write_fixture(dir, "ratemap_inverse_cancel", (AstMapping*)cm);
+        cm = astAnnul(cm); r1 = astAnnul(r1); r2 = astAnnul(r2);
+        z1 = astAnnul(z1); z2 = astAnnul(z2);
+    }
 }
 
 /* ===== SlaMap fixtures ===== */
@@ -820,6 +834,11 @@ static void gen_unitnormmap_fixtures(const char *dir) {
 
 /* ===== GrismMap fixtures ===== */
 
+#define GRISM_PARAMS \
+    "GrismNR=1.5,GrismNRP=-1e-6,GrismWaveR=5000," \
+    "GrismAlpha=0.1,GrismG=2e-4,GrismM=1," \
+    "GrismEps=0.02,GrismTheta=0.03"
+
 static void gen_grismmap_fixtures(const char *dir) {
     printf("GrismMap fixtures:\n");
 
@@ -831,6 +850,28 @@ static void gen_grismmap_fixtures(const char *dir) {
         AstCmpMap *cm = astCmpMap(zm, gm, 1, "");
         write_fixture(dir, "grism_zoom_inv_merge", (AstMapping*)cm);
         cm = astAnnul(cm); gm = astAnnul(gm); zm = astAnnul(zm);
+    }
+
+    /* grismmap-01: forward GrismMap + ZoomMap → merge into a single GrismMap */
+    {
+        AstGrismMap *gm = astGrismMap(GRISM_PARAMS);
+        AstZoomMap *zm = astZoomMap(1, 2.0, "");
+        AstCmpMap *cm = astCmpMap(gm, zm, 1, "");
+        write_fixture(dir, "grism_zoom_merge", (AstMapping*)cm);
+        cm = astAnnul(cm); gm = astAnnul(gm); zm = astAnnul(zm);
+    }
+
+    /* grismmap-02: forward GrismMap + inverted GrismMap (opposite GrmM) → cancel */
+    {
+        AstGrismMap *g1 = astGrismMap(GRISM_PARAMS);
+        AstGrismMap *g2 = astGrismMap(
+            "GrismNR=1.5,GrismNRP=-1e-6,GrismWaveR=5000,"
+            "GrismAlpha=0.1,GrismG=2e-4,GrismM=-1,"
+            "GrismEps=0.02,GrismTheta=0.03");
+        astInvert(g2);
+        AstCmpMap *cm = astCmpMap(g1, g2, 1, "");
+        write_fixture(dir, "grism_inverse_cancel", (AstMapping*)cm);
+        cm = astAnnul(cm); g1 = astAnnul(g1); g2 = astAnnul(g2);
     }
 }
 
@@ -888,6 +929,23 @@ static void gen_sphmap_fixtures(const char *dir) {
         write_fixture(dir, "sph_zoom_sandwich", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         s1 = astAnnul(s1); zm = astAnnul(zm); s2 = astAnnul(s2);
+    }
+
+    /* sphmap-XX: Inv(SphMap) + (Diagonal MatrixMap + SphMap) → MatrixMap.
+       Tests the SphMap sandwich simplification with an explicit non-unit
+       diagonal matrix in the middle. Setting PolarLong=0 explicitly so
+       the resulting fixture pins PlrLg with a "set" flag. */
+    {
+        AstSphMap *s1 = astSphMap("PolarLong=0");
+        astInvert(s1);
+        double diag[] = {2.0, -2.0, 2.0};
+        AstMatrixMap *mm = astMatrixMap(3, 3, 1, diag, "");
+        AstSphMap *s2 = astSphMap("PolarLong=0");
+        AstCmpMap *inner = astCmpMap(mm, s2, 1, "");
+        AstCmpMap *outer = astCmpMap(s1, inner, 1, "");
+        write_fixture(dir, "sph_matrix_sandwich", (AstMapping*)outer);
+        outer = astAnnul(outer); inner = astAnnul(inner);
+        s1 = astAnnul(s1); mm = astAnnul(mm); s2 = astAnnul(s2);
     }
 }
 

--- a/ast_tester/simplify_fixtures/box_self_simplify.map
+++ b/ast_tester/simplify_fixtures/box_self_simplify.map
@@ -1,0 +1,35 @@
+ Begin Box 	# Axis intervals
+#   Title = "2-d coordinate system" 	# Title of coordinate system
+#   Naxes = 2 	# Number of coordinate axes
+#   Domain = "ZOOMED" 	# Coordinate system domain
+#   Epoch = 2000 	# Julian epoch of observation
+#   Lbl1 = "Axis 1" 	# Label for axis 1
+#   Lbl2 = "Axis 2" 	# Label for axis 2
+#   System = "Cartesian" 	# Coordinate system type
+ IsA Frame 	# Coordinate system description
+    Adapt = 1 	# Region adapts to coord sys changes
+    Frm = 	# Coordinate system
+       Begin Frame 	# Coordinate system description
+#         Title = "2-d coordinate system" 	# Title of coordinate system
+          Naxes = 2 	# Number of coordinate axes
+          Domain = "ZOOMED" 	# Coordinate system domain
+#         Lbl1 = "Axis 1" 	# Label for axis 1
+#         Lbl2 = "Axis 2" 	# Label for axis 2
+          Ax1 = 	# Axis number 1
+             Begin Axis 	# Coordinate axis
+             End Axis
+          Ax2 = 	# Axis number 2
+             Begin Axis 	# Coordinate axis
+             End Axis
+       End Frame
+    Points = 	# Points defining the shape
+       Begin PointSet 	# Container for a set of points
+          Npoint = 2 	# Number of points
+          Ncoord = 2 	# Number of coordinates per point
+          X1 = 30 	# Coordinate values...
+          X2 = 30
+          X3 = 60
+          X4 = 60
+       End PointSet
+ IsA Region 	# An area within a coordinate system
+ End Box

--- a/ast_tester/simplify_fixtures/box_self_simplify.simp
+++ b/ast_tester/simplify_fixtures/box_self_simplify.simp
@@ -1,0 +1,35 @@
+ Begin Box 	# Axis intervals
+#   Title = "2-d coordinate system" 	# Title of coordinate system
+#   Naxes = 2 	# Number of coordinate axes
+#   Domain = "ZOOMED" 	# Coordinate system domain
+#   Epoch = 2000 	# Julian epoch of observation
+#   Lbl1 = "Axis 1" 	# Label for axis 1
+#   Lbl2 = "Axis 2" 	# Label for axis 2
+#   System = "Cartesian" 	# Coordinate system type
+ IsA Frame 	# Coordinate system description
+    Adapt = 1 	# Region adapts to coord sys changes
+    Frm = 	# Coordinate system
+       Begin Frame 	# Coordinate system description
+#         Title = "2-d coordinate system" 	# Title of coordinate system
+          Naxes = 2 	# Number of coordinate axes
+          Domain = "ZOOMED" 	# Coordinate system domain
+#         Lbl1 = "Axis 1" 	# Label for axis 1
+#         Lbl2 = "Axis 2" 	# Label for axis 2
+          Ax1 = 	# Axis number 1
+             Begin Axis 	# Coordinate axis
+             End Axis
+          Ax2 = 	# Axis number 2
+             Begin Axis 	# Coordinate axis
+             End Axis
+       End Frame
+    Points = 	# Points defining the shape
+       Begin PointSet 	# Container for a set of points
+          Npoint = 2 	# Number of points
+          Ncoord = 2 	# Number of coordinates per point
+          X1 = 30 	# Coordinate values...
+          X2 = 30
+          X3 = 60
+          X4 = 60
+       End PointSet
+ IsA Region 	# An area within a coordinate system
+ End Box

--- a/ast_tester/simplify_fixtures/chebymap_inverse_cancel.map
+++ b/ast_tester/simplify_fixtures/chebymap_inverse_cancel.map
@@ -1,0 +1,42 @@
+ Begin CmpMap 	# Compound Mapping
+    Nin = 1 	# Number of input coordinates
+ IsA Mapping 	# Mapping between coordinate systems
+    InvB = 1 	# Second Mapping used in inverse direction
+    MapA = 	# First component Mapping
+       Begin ChebyMap 	# Chebyshev polynomial transformation
+          Nin = 1 	# Number of input coordinates
+       IsA Mapping 	# Mapping between coordinate systems
+          MPF1 = 1 	# Max. power of input 1 in any forward polynomial
+          NCF1 = 1 	# No. of coeff.s for forward polynomial 1
+          CF1 = 0.5 	# Coeff 1 of forward polynomial 1
+          PF1 = 1 	# Power of i/p 1 for coeff 1 of fwd poly 1
+          MPI1 = 1 	# Max. power of output 1 in any inverse polynomial
+          NCI1 = 1 	# No. of coeff.s for inverse polynomial 1
+          CI1 = 2 	# Coeff 1 of inverse polynomial 1
+          PI1 = 1 	# Power of o/p 1 for coeff 1 of inv poly 1
+       IsA PolyMap 	# Polynomial transformation
+          FSCL1 = 1 	# Scale factor on input 1
+          FOFF1 = 0 	# Offset on input 1
+          ISCL1 = 1 	# Scale factor on output 1
+          IOFF1 = 0 	# Offset on output 1
+       End ChebyMap
+    MapB = 	# Second component Mapping
+       Begin ChebyMap 	# Chebyshev polynomial transformation
+          Nin = 1 	# Number of input coordinates
+          Invert = 1 	# Mapping inverted
+       IsA Mapping 	# Mapping between coordinate systems
+          MPF1 = 1 	# Max. power of input 1 in any forward polynomial
+          NCF1 = 1 	# No. of coeff.s for forward polynomial 1
+          CF1 = 0.5 	# Coeff 1 of forward polynomial 1
+          PF1 = 1 	# Power of i/p 1 for coeff 1 of fwd poly 1
+          MPI1 = 1 	# Max. power of output 1 in any inverse polynomial
+          NCI1 = 1 	# No. of coeff.s for inverse polynomial 1
+          CI1 = 2 	# Coeff 1 of inverse polynomial 1
+          PI1 = 1 	# Power of o/p 1 for coeff 1 of inv poly 1
+       IsA PolyMap 	# Polynomial transformation
+          FSCL1 = 1 	# Scale factor on input 1
+          FOFF1 = 0 	# Offset on input 1
+          ISCL1 = 1 	# Scale factor on output 1
+          IOFF1 = 0 	# Offset on output 1
+       End ChebyMap
+ End CmpMap

--- a/ast_tester/simplify_fixtures/chebymap_inverse_cancel.simp
+++ b/ast_tester/simplify_fixtures/chebymap_inverse_cancel.simp
@@ -1,0 +1,5 @@
+ Begin UnitMap 	# Unit (null) Mapping
+    Nin = 1 	# Number of input coordinates
+    IsSimp = 1 	# Mapping has been simplified
+ IsA Mapping 	# Mapping between coordinate systems
+ End UnitMap

--- a/ast_tester/simplify_fixtures/grism_inverse_cancel.map
+++ b/ast_tester/simplify_fixtures/grism_inverse_cancel.map
@@ -4,6 +4,8 @@
     InvB = 1 	# Second Mapping used in inverse direction
     MapA = 	# First component Mapping
        Begin GrismMap 	# Map 1-d coordinates using a spectral disperser
+          Nin = 1 	# Number of input coordinates
+       IsA Mapping 	# Mapping between coordinate systems
           GrmNR = 1.5 	# Refractive index at the ref. wavelength
           GrmNRP = -9.9999999999999995e-07 	# Rate of change of refractive index
           GrmWR = 5000 	# Ref. wavelength
@@ -15,6 +17,9 @@
        End GrismMap
     MapB = 	# Second component Mapping
        Begin GrismMap 	# Map 1-d coordinates using a spectral disperser
+          Nin = 1 	# Number of input coordinates
+          Invert = 1 	# Mapping inverted
+       IsA Mapping 	# Mapping between coordinate systems
           GrmNR = 1.5 	# Refractive index at the ref. wavelength
           GrmNRP = -9.9999999999999995e-07 	# Rate of change of refractive index
           GrmWR = 5000 	# Ref. wavelength

--- a/ast_tester/simplify_fixtures/grism_zoom_merge.map
+++ b/ast_tester/simplify_fixtures/grism_zoom_merge.map
@@ -3,6 +3,8 @@
  IsA Mapping 	# Mapping between coordinate systems
     MapA = 	# First component Mapping
        Begin GrismMap 	# Map 1-d coordinates using a spectral disperser
+          Nin = 1 	# Number of input coordinates
+       IsA Mapping 	# Mapping between coordinate systems
           GrmNR = 1.5 	# Refractive index at the ref. wavelength
           GrmNRP = -9.9999999999999995e-07 	# Rate of change of refractive index
           GrmWR = 5000 	# Ref. wavelength

--- a/ast_tester/simplify_fixtures/grism_zoom_merge.simp
+++ b/ast_tester/simplify_fixtures/grism_zoom_merge.simp
@@ -1,4 +1,5 @@
  Begin GrismMap 	# Map 1-d coordinates using a spectral disperser
+    Nin = 1 	# Number of input coordinates
     IsSimp = 1 	# Mapping has been simplified
  IsA Mapping 	# Mapping between coordinate systems
     GrmNR = 1.5 	# Refractive index at the ref. wavelength

--- a/ast_tester/simplify_fixtures/interval_self_simplify.map
+++ b/ast_tester/simplify_fixtures/interval_self_simplify.map
@@ -1,0 +1,35 @@
+ Begin Interval 	# Axis intervals
+#   Title = "2-d coordinate system" 	# Title of coordinate system
+#   Naxes = 2 	# Number of coordinate axes
+#   Domain = "ZOOMED" 	# Coordinate system domain
+#   Epoch = 2000 	# Julian epoch of observation
+#   Lbl1 = "Axis 1" 	# Label for axis 1
+#   Lbl2 = "Axis 2" 	# Label for axis 2
+#   System = "Cartesian" 	# Coordinate system type
+ IsA Frame 	# Coordinate system description
+    Adapt = 1 	# Region adapts to coord sys changes
+    Frm = 	# Coordinate system
+       Begin Frame 	# Coordinate system description
+#         Title = "2-d coordinate system" 	# Title of coordinate system
+          Naxes = 2 	# Number of coordinate axes
+          Domain = "ZOOMED" 	# Coordinate system domain
+#         Lbl1 = "Axis 1" 	# Label for axis 1
+#         Lbl2 = "Axis 2" 	# Label for axis 2
+          Ax1 = 	# Axis number 1
+             Begin Axis 	# Coordinate axis
+             End Axis
+          Ax2 = 	# Axis number 2
+             Begin Axis 	# Coordinate axis
+             End Axis
+       End Frame
+    Points = 	# Points defining the shape
+       Begin PointSet 	# Container for a set of points
+          Npoint = 2 	# Number of points
+          Ncoord = 2 	# Number of coordinates per point
+          X1 = 0 	# Coordinate values...
+          X2 = 0
+          X3 = 10
+          X4 = 10
+       End PointSet
+ IsA Region 	# An area within a coordinate system
+ End Interval

--- a/ast_tester/simplify_fixtures/interval_self_simplify.simp
+++ b/ast_tester/simplify_fixtures/interval_self_simplify.simp
@@ -1,0 +1,36 @@
+ Begin Box 	# Axis intervals
+#   Title = "2-d coordinate system" 	# Title of coordinate system
+#   Naxes = 2 	# Number of coordinate axes
+#   Domain = "ZOOMED" 	# Coordinate system domain
+#   Epoch = 2000 	# Julian epoch of observation
+#   Lbl1 = "Axis 1" 	# Label for axis 1
+#   Lbl2 = "Axis 2" 	# Label for axis 2
+#   System = "Cartesian" 	# Coordinate system type
+ IsA Frame 	# Coordinate system description
+    Closed = 1 	# Boundary is inside
+    Adapt = 1 	# Region adapts to coord sys changes
+    Frm = 	# Coordinate system
+       Begin Frame 	# Coordinate system description
+#         Title = "2-d coordinate system" 	# Title of coordinate system
+          Naxes = 2 	# Number of coordinate axes
+          Domain = "ZOOMED" 	# Coordinate system domain
+#         Lbl1 = "Axis 1" 	# Label for axis 1
+#         Lbl2 = "Axis 2" 	# Label for axis 2
+          Ax1 = 	# Axis number 1
+             Begin Axis 	# Coordinate axis
+             End Axis
+          Ax2 = 	# Axis number 2
+             Begin Axis 	# Coordinate axis
+             End Axis
+       End Frame
+    Points = 	# Points defining the shape
+       Begin PointSet 	# Container for a set of points
+          Npoint = 2 	# Number of points
+          Ncoord = 2 	# Number of coordinates per point
+          X1 = 5 	# Coordinate values...
+          X2 = 5
+          X3 = 10
+          X4 = 10
+       End PointSet
+ IsA Region 	# An area within a coordinate system
+ End Box

--- a/ast_tester/simplify_fixtures/neg_chebymap_standalone.map
+++ b/ast_tester/simplify_fixtures/neg_chebymap_standalone.map
@@ -1,0 +1,25 @@
+ Begin ChebyMap 	# Chebyshev polynomial transformation
+    Nin = 2 	# Number of input coordinates
+ IsA Mapping 	# Mapping between coordinate systems
+    MPF1 = 2 	# Max. power of input 1 in any forward polynomial
+    MPF2 = 2 	# Max. power of input 2 in any forward polynomial
+    NCF1 = 3 	# No. of coeff.s for forward polynomial 1
+    NCF2 = 3 	# No. of coeff.s for forward polynomial 2
+    CF1 = 1 	# Coeff 1 of forward polynomial 1
+    CF2 = 0.050000000000000003 	# Coeff 2 of forward polynomial 1
+    CF3 = 0.02 	# Coeff 3 of forward polynomial 1
+    CF4 = 1 	# Coeff 1 of forward polynomial 2
+    CF5 = 0.050000000000000003 	# Coeff 2 of forward polynomial 2
+    CF6 = 0.02 	# Coeff 3 of forward polynomial 2
+    PF1 = 1 	# Power of i/p 1 for coeff 1 of fwd poly 1
+    PF4 = 1 	# Power of i/p 2 for coeff 2 of fwd poly 1
+    PF5 = 2 	# Power of i/p 1 for coeff 3 of fwd poly 1
+    PF8 = 1 	# Power of i/p 2 for coeff 1 of fwd poly 2
+    PF9 = 1 	# Power of i/p 1 for coeff 2 of fwd poly 2
+    PF12 = 2 	# Power of i/p 2 for coeff 3 of fwd poly 2
+ IsA PolyMap 	# Polynomial transformation
+    FSCL1 = 0.5 	# Scale factor on input 1
+    FSCL2 = 0.5 	# Scale factor on input 2
+    FOFF1 = 0 	# Offset on input 1
+    FOFF2 = 0 	# Offset on input 2
+ End ChebyMap

--- a/ast_tester/simplify_fixtures/neg_time_5arg_mismatch.map
+++ b/ast_tester/simplify_fixtures/neg_time_5arg_mismatch.map
@@ -8,7 +8,7 @@
     Time1c = -2.5 	# Observer latitude
     Time1d = 6378 	# Observer altitude
     Time1e = -5121.0504050301515 	# Distance from earth spin axis
-    Time1f = -3799.9547800119039 	# Distance north of equatorial plane
+    Time1f = -3799.9547800119035 	# Distance north of equatorial plane
     Time1g = 0 	# DTAI
     Time2 = "TDBTOTT" 	# Convert TDB to TT
     Time2a = 53000 	# MJD offset

--- a/ast_tester/simplify_fixtures/normmap_frame_simplifies.map
+++ b/ast_tester/simplify_fixtures/normmap_frame_simplifies.map
@@ -1,0 +1,40 @@
+ Begin NormMap 	# Normalise axis values
+    Nin = 2 	# Number of input coordinates
+ IsA Mapping 	# Mapping between coordinate systems
+    Frame = 	# Frame defining the normalisation
+       Begin Box 	# Axis intervals
+#         Title = "2-d coordinate system" 	# Title of coordinate system
+#         Naxes = 2 	# Number of coordinate axes
+#         Domain = "ZOOMED" 	# Coordinate system domain
+#         Epoch = 2000 	# Julian epoch of observation
+#         Lbl1 = "Axis 1" 	# Label for axis 1
+#         Lbl2 = "Axis 2" 	# Label for axis 2
+#         System = "Cartesian" 	# Coordinate system type
+       IsA Frame 	# Coordinate system description
+          Adapt = 1 	# Region adapts to coord sys changes
+          Frm = 	# Coordinate system
+             Begin Frame 	# Coordinate system description
+#               Title = "2-d coordinate system" 	# Title of coordinate system
+                Naxes = 2 	# Number of coordinate axes
+                Domain = "ZOOMED" 	# Coordinate system domain
+#               Lbl1 = "Axis 1" 	# Label for axis 1
+#               Lbl2 = "Axis 2" 	# Label for axis 2
+                Ax1 = 	# Axis number 1
+                   Begin Axis 	# Coordinate axis
+                   End Axis
+                Ax2 = 	# Axis number 2
+                   Begin Axis 	# Coordinate axis
+                   End Axis
+             End Frame
+          Points = 	# Points defining the shape
+             Begin PointSet 	# Container for a set of points
+                Npoint = 2 	# Number of points
+                Ncoord = 2 	# Number of coordinates per point
+                X1 = 5 	# Coordinate values...
+                X2 = 5
+                X3 = 10
+                X4 = 10
+             End PointSet
+       IsA Region 	# An area within a coordinate system
+       End Box
+ End NormMap

--- a/ast_tester/simplify_fixtures/normmap_frame_simplifies.simp
+++ b/ast_tester/simplify_fixtures/normmap_frame_simplifies.simp
@@ -1,0 +1,41 @@
+ Begin NormMap 	# Normalise axis values
+    Nin = 2 	# Number of input coordinates
+    IsSimp = 1 	# Mapping has been simplified
+ IsA Mapping 	# Mapping between coordinate systems
+    Frame = 	# Frame defining the normalisation
+       Begin Box 	# Axis intervals
+#         Title = "2-d coordinate system" 	# Title of coordinate system
+#         Naxes = 2 	# Number of coordinate axes
+#         Domain = "ZOOMED" 	# Coordinate system domain
+#         Epoch = 2000 	# Julian epoch of observation
+#         Lbl1 = "Axis 1" 	# Label for axis 1
+#         Lbl2 = "Axis 2" 	# Label for axis 2
+#         System = "Cartesian" 	# Coordinate system type
+       IsA Frame 	# Coordinate system description
+          Adapt = 1 	# Region adapts to coord sys changes
+          Frm = 	# Coordinate system
+             Begin Frame 	# Coordinate system description
+#               Title = "2-d coordinate system" 	# Title of coordinate system
+                Naxes = 2 	# Number of coordinate axes
+                Domain = "ZOOMED" 	# Coordinate system domain
+#               Lbl1 = "Axis 1" 	# Label for axis 1
+#               Lbl2 = "Axis 2" 	# Label for axis 2
+                Ax1 = 	# Axis number 1
+                   Begin Axis 	# Coordinate axis
+                   End Axis
+                Ax2 = 	# Axis number 2
+                   Begin Axis 	# Coordinate axis
+                   End Axis
+             End Frame
+          Points = 	# Points defining the shape
+             Begin PointSet 	# Container for a set of points
+                Npoint = 2 	# Number of points
+                Ncoord = 2 	# Number of coordinates per point
+                X1 = 5 	# Coordinate values...
+                X2 = 5
+                X3 = 10
+                X4 = 10
+             End PointSet
+       IsA Region 	# An area within a coordinate system
+       End Box
+ End NormMap

--- a/ast_tester/simplify_fixtures/nullregion_parallel_merge.map
+++ b/ast_tester/simplify_fixtures/nullregion_parallel_merge.map
@@ -1,0 +1,53 @@
+ Begin CmpMap 	# Compound Mapping
+    Nin = 2 	# Number of input coordinates
+ IsA Mapping 	# Mapping between coordinate systems
+    Series = 0 	# Component Mappings applied in parallel
+    MapA = 	# First component Mapping
+       Begin NullRegion 	# Boundless region
+#         Title = "1-d coordinate system" 	# Title of coordinate system
+#         Naxes = 1 	# Number of coordinate axes
+#         Epoch = 2000 	# Julian epoch of observation
+#         Lbl1 = "Axis 1" 	# Label for axis 1
+#         System = "Cartesian" 	# Coordinate system type
+       IsA Frame 	# Coordinate system description
+          Adapt = 1 	# Region adapts to coord sys changes
+          Frm = 	# Coordinate system
+             Begin Frame 	# Coordinate system description
+#               Title = "1-d coordinate system" 	# Title of coordinate system
+                Naxes = 1 	# Number of coordinate axes
+#               Lbl1 = "Axis 1" 	# Label for axis 1
+                Ax1 = 	# Axis number 1
+                   Begin Axis 	# Coordinate axis
+                   End Axis
+             End Frame
+          RegAxes = 1 	# Number of axes spanned by the Region
+       IsA Region 	# An area within a coordinate system
+       End NullRegion
+    MapB = 	# Second component Mapping
+       Begin Box 	# Axis intervals
+#         Title = "1-d coordinate system" 	# Title of coordinate system
+#         Naxes = 1 	# Number of coordinate axes
+#         Epoch = 2000 	# Julian epoch of observation
+#         Lbl1 = "Axis 1" 	# Label for axis 1
+#         System = "Cartesian" 	# Coordinate system type
+       IsA Frame 	# Coordinate system description
+          Adapt = 1 	# Region adapts to coord sys changes
+          Frm = 	# Coordinate system
+             Begin Frame 	# Coordinate system description
+#               Title = "1-d coordinate system" 	# Title of coordinate system
+                Naxes = 1 	# Number of coordinate axes
+#               Lbl1 = "Axis 1" 	# Label for axis 1
+                Ax1 = 	# Axis number 1
+                   Begin Axis 	# Coordinate axis
+                   End Axis
+             End Frame
+          Points = 	# Points defining the shape
+             Begin PointSet 	# Container for a set of points
+                Npoint = 2 	# Number of points
+                Ncoord = 1 	# Number of coordinates per point
+                X1 = 5 	# Coordinate values...
+                X2 = 10
+             End PointSet
+       IsA Region 	# An area within a coordinate system
+       End Box
+ End CmpMap

--- a/ast_tester/simplify_fixtures/nullregion_parallel_merge.simp
+++ b/ast_tester/simplify_fixtures/nullregion_parallel_merge.simp
@@ -1,0 +1,54 @@
+ Begin CmpMap 	# Compound Mapping
+    Nin = 2 	# Number of input coordinates
+    IsSimp = 1 	# Mapping has been simplified
+ IsA Mapping 	# Mapping between coordinate systems
+    Series = 0 	# Component Mappings applied in parallel
+    MapA = 	# First component Mapping
+       Begin NullRegion 	# Boundless region
+#         Title = "1-d coordinate system" 	# Title of coordinate system
+#         Naxes = 1 	# Number of coordinate axes
+#         Epoch = 2000 	# Julian epoch of observation
+#         Lbl1 = "Axis 1" 	# Label for axis 1
+#         System = "Cartesian" 	# Coordinate system type
+       IsA Frame 	# Coordinate system description
+          Adapt = 1 	# Region adapts to coord sys changes
+          Frm = 	# Coordinate system
+             Begin Frame 	# Coordinate system description
+#               Title = "1-d coordinate system" 	# Title of coordinate system
+                Naxes = 1 	# Number of coordinate axes
+#               Lbl1 = "Axis 1" 	# Label for axis 1
+                Ax1 = 	# Axis number 1
+                   Begin Axis 	# Coordinate axis
+                   End Axis
+             End Frame
+          RegAxes = 1 	# Number of axes spanned by the Region
+       IsA Region 	# An area within a coordinate system
+       End NullRegion
+    MapB = 	# Second component Mapping
+       Begin Box 	# Axis intervals
+#         Title = "1-d coordinate system" 	# Title of coordinate system
+#         Naxes = 1 	# Number of coordinate axes
+#         Epoch = 2000 	# Julian epoch of observation
+#         Lbl1 = "Axis 1" 	# Label for axis 1
+#         System = "Cartesian" 	# Coordinate system type
+       IsA Frame 	# Coordinate system description
+          Adapt = 1 	# Region adapts to coord sys changes
+          Frm = 	# Coordinate system
+             Begin Frame 	# Coordinate system description
+#               Title = "1-d coordinate system" 	# Title of coordinate system
+                Naxes = 1 	# Number of coordinate axes
+#               Lbl1 = "Axis 1" 	# Label for axis 1
+                Ax1 = 	# Axis number 1
+                   Begin Axis 	# Coordinate axis
+                   End Axis
+             End Frame
+          Points = 	# Points defining the shape
+             Begin PointSet 	# Container for a set of points
+                Npoint = 2 	# Number of points
+                Ncoord = 1 	# Number of coordinates per point
+                X1 = 5 	# Coordinate values...
+                X2 = 10
+             End PointSet
+       IsA Region 	# An area within a coordinate system
+       End Box
+ End CmpMap

--- a/ast_tester/simplify_fixtures/nullregion_self_simplify.map
+++ b/ast_tester/simplify_fixtures/nullregion_self_simplify.map
@@ -1,0 +1,27 @@
+ Begin NullRegion 	# Boundless region
+#   Title = "2-d coordinate system" 	# Title of coordinate system
+#   Naxes = 2 	# Number of coordinate axes
+#   Domain = "ZOOMED" 	# Coordinate system domain
+#   Epoch = 2000 	# Julian epoch of observation
+#   Lbl1 = "Axis 1" 	# Label for axis 1
+#   Lbl2 = "Axis 2" 	# Label for axis 2
+#   System = "Cartesian" 	# Coordinate system type
+ IsA Frame 	# Coordinate system description
+    Adapt = 1 	# Region adapts to coord sys changes
+    Frm = 	# Coordinate system
+       Begin Frame 	# Coordinate system description
+#         Title = "2-d coordinate system" 	# Title of coordinate system
+          Naxes = 2 	# Number of coordinate axes
+          Domain = "ZOOMED" 	# Coordinate system domain
+#         Lbl1 = "Axis 1" 	# Label for axis 1
+#         Lbl2 = "Axis 2" 	# Label for axis 2
+          Ax1 = 	# Axis number 1
+             Begin Axis 	# Coordinate axis
+             End Axis
+          Ax2 = 	# Axis number 2
+             Begin Axis 	# Coordinate axis
+             End Axis
+       End Frame
+    RegAxes = 2 	# Number of axes spanned by the Region
+ IsA Region 	# An area within a coordinate system
+ End NullRegion

--- a/ast_tester/simplify_fixtures/nullregion_self_simplify.simp
+++ b/ast_tester/simplify_fixtures/nullregion_self_simplify.simp
@@ -1,0 +1,27 @@
+ Begin NullRegion 	# Boundless region
+#   Title = "2-d coordinate system" 	# Title of coordinate system
+#   Naxes = 2 	# Number of coordinate axes
+#   Domain = "ZOOMED" 	# Coordinate system domain
+#   Epoch = 2000 	# Julian epoch of observation
+#   Lbl1 = "Axis 1" 	# Label for axis 1
+#   Lbl2 = "Axis 2" 	# Label for axis 2
+#   System = "Cartesian" 	# Coordinate system type
+ IsA Frame 	# Coordinate system description
+    Adapt = 1 	# Region adapts to coord sys changes
+    Frm = 	# Coordinate system
+       Begin Frame 	# Coordinate system description
+#         Title = "2-d coordinate system" 	# Title of coordinate system
+          Naxes = 2 	# Number of coordinate axes
+          Domain = "ZOOMED" 	# Coordinate system domain
+#         Lbl1 = "Axis 1" 	# Label for axis 1
+#         Lbl2 = "Axis 2" 	# Label for axis 2
+          Ax1 = 	# Axis number 1
+             Begin Axis 	# Coordinate axis
+             End Axis
+          Ax2 = 	# Axis number 2
+             Begin Axis 	# Coordinate axis
+             End Axis
+       End Frame
+    RegAxes = 2 	# Number of axes spanned by the Region
+ IsA Region 	# An area within a coordinate system
+ End NullRegion

--- a/ast_tester/simplify_fixtures/pointlist_self_simplify.map
+++ b/ast_tester/simplify_fixtures/pointlist_self_simplify.map
@@ -1,0 +1,35 @@
+ Begin PointList 	# Collection of points
+#   Title = "2-d coordinate system" 	# Title of coordinate system
+#   Naxes = 2 	# Number of coordinate axes
+#   Domain = "ZOOMED" 	# Coordinate system domain
+#   Epoch = 2000 	# Julian epoch of observation
+#   Lbl1 = "Axis 1" 	# Label for axis 1
+#   Lbl2 = "Axis 2" 	# Label for axis 2
+#   System = "Cartesian" 	# Coordinate system type
+ IsA Frame 	# Coordinate system description
+    Adapt = 1 	# Region adapts to coord sys changes
+    Frm = 	# Coordinate system
+       Begin Frame 	# Coordinate system description
+#         Title = "2-d coordinate system" 	# Title of coordinate system
+          Naxes = 2 	# Number of coordinate axes
+          Domain = "ZOOMED" 	# Coordinate system domain
+#         Lbl1 = "Axis 1" 	# Label for axis 1
+#         Lbl2 = "Axis 2" 	# Label for axis 2
+          Ax1 = 	# Axis number 1
+             Begin Axis 	# Coordinate axis
+             End Axis
+          Ax2 = 	# Axis number 2
+             Begin Axis 	# Coordinate axis
+             End Axis
+       End Frame
+    Points = 	# Points defining the shape
+       Begin PointSet 	# Container for a set of points
+          Npoint = 2 	# Number of points
+          Ncoord = 2 	# Number of coordinates per point
+          X1 = 1 	# Coordinate values...
+          X2 = 3
+          X3 = 2
+          X4 = 4
+       End PointSet
+ IsA Region 	# An area within a coordinate system
+ End PointList

--- a/ast_tester/simplify_fixtures/pointlist_self_simplify.simp
+++ b/ast_tester/simplify_fixtures/pointlist_self_simplify.simp
@@ -1,0 +1,35 @@
+ Begin PointList 	# Collection of points
+#   Title = "2-d coordinate system" 	# Title of coordinate system
+#   Naxes = 2 	# Number of coordinate axes
+#   Domain = "ZOOMED" 	# Coordinate system domain
+#   Epoch = 2000 	# Julian epoch of observation
+#   Lbl1 = "Axis 1" 	# Label for axis 1
+#   Lbl2 = "Axis 2" 	# Label for axis 2
+#   System = "Cartesian" 	# Coordinate system type
+ IsA Frame 	# Coordinate system description
+    Adapt = 1 	# Region adapts to coord sys changes
+    Frm = 	# Coordinate system
+       Begin Frame 	# Coordinate system description
+#         Title = "2-d coordinate system" 	# Title of coordinate system
+          Naxes = 2 	# Number of coordinate axes
+          Domain = "ZOOMED" 	# Coordinate system domain
+#         Lbl1 = "Axis 1" 	# Label for axis 1
+#         Lbl2 = "Axis 2" 	# Label for axis 2
+          Ax1 = 	# Axis number 1
+             Begin Axis 	# Coordinate axis
+             End Axis
+          Ax2 = 	# Axis number 2
+             Begin Axis 	# Coordinate axis
+             End Axis
+       End Frame
+    Points = 	# Points defining the shape
+       Begin PointSet 	# Container for a set of points
+          Npoint = 2 	# Number of points
+          Ncoord = 2 	# Number of coordinates per point
+          X1 = 1 	# Coordinate values...
+          X2 = 3
+          X3 = 2
+          X4 = 4
+       End PointSet
+ IsA Region 	# An area within a coordinate system
+ End PointList

--- a/ast_tester/simplify_fixtures/ratemap_inverse_cancel.map
+++ b/ast_tester/simplify_fixtures/ratemap_inverse_cancel.map
@@ -1,10 +1,13 @@
  Begin CmpMap 	# Compound Mapping
     Nin = 1 	# Number of input coordinates
+    Fwd = 0 	# Forward transformation not defined
+    Inv = 0 	# Inverse transformation not defined
  IsA Mapping 	# Mapping between coordinate systems
     InvB = 1 	# Second Mapping used in inverse direction
     MapA = 	# First component Mapping
        Begin RateMap 	# Differential Mapping
           Nin = 1 	# Number of input coordinates
+          Inv = 0 	# Inverse transformation not defined
        IsA Mapping 	# Mapping between coordinate systems
           Map = 	# Mapping to be differentiated
              Begin ZoomMap 	# Zoom about the origin
@@ -16,6 +19,8 @@
     MapB = 	# Second component Mapping
        Begin RateMap 	# Differential Mapping
           Nin = 1 	# Number of input coordinates
+          Invert = 1 	# Mapping inverted
+          Inv = 0 	# Inverse transformation not defined
        IsA Mapping 	# Mapping between coordinate systems
           Map = 	# Mapping to be differentiated
              Begin ZoomMap 	# Zoom about the origin

--- a/ast_tester/simplify_fixtures/selectormap_region_simplify.map
+++ b/ast_tester/simplify_fixtures/selectormap_region_simplify.map
@@ -1,0 +1,42 @@
+ Begin SelectorMap 	# Region identification Mapping
+    Nin = 2 	# Number of input coordinates
+    Nout = 1 	# Number of output coordinates
+    Inv = 0 	# Inverse transformation not defined
+ IsA Mapping 	# Mapping between coordinate systems
+    Reg1 = 	# Region of input space
+       Begin Box 	# Axis intervals
+#         Title = "2-d coordinate system" 	# Title of coordinate system
+#         Naxes = 2 	# Number of coordinate axes
+#         Domain = "ZOOMED" 	# Coordinate system domain
+#         Epoch = 2000 	# Julian epoch of observation
+#         Lbl1 = "Axis 1" 	# Label for axis 1
+#         Lbl2 = "Axis 2" 	# Label for axis 2
+#         System = "Cartesian" 	# Coordinate system type
+       IsA Frame 	# Coordinate system description
+          Adapt = 1 	# Region adapts to coord sys changes
+          Frm = 	# Coordinate system
+             Begin Frame 	# Coordinate system description
+#               Title = "2-d coordinate system" 	# Title of coordinate system
+                Naxes = 2 	# Number of coordinate axes
+                Domain = "ZOOMED" 	# Coordinate system domain
+#               Lbl1 = "Axis 1" 	# Label for axis 1
+#               Lbl2 = "Axis 2" 	# Label for axis 2
+                Ax1 = 	# Axis number 1
+                   Begin Axis 	# Coordinate axis
+                   End Axis
+                Ax2 = 	# Axis number 2
+                   Begin Axis 	# Coordinate axis
+                   End Axis
+             End Frame
+          Points = 	# Points defining the shape
+             Begin PointSet 	# Container for a set of points
+                Npoint = 2 	# Number of points
+                Ncoord = 2 	# Number of coordinates per point
+                X1 = 5 	# Coordinate values...
+                X2 = 5
+                X3 = 10
+                X4 = 10
+             End PointSet
+       IsA Region 	# An area within a coordinate system
+       End Box
+ End SelectorMap

--- a/ast_tester/simplify_fixtures/selectormap_region_simplify.simp
+++ b/ast_tester/simplify_fixtures/selectormap_region_simplify.simp
@@ -1,0 +1,43 @@
+ Begin SelectorMap 	# Region identification Mapping
+    Nin = 2 	# Number of input coordinates
+    Nout = 1 	# Number of output coordinates
+    IsSimp = 1 	# Mapping has been simplified
+    Inv = 0 	# Inverse transformation not defined
+ IsA Mapping 	# Mapping between coordinate systems
+    Reg1 = 	# Region of input space
+       Begin Box 	# Axis intervals
+#         Title = "2-d coordinate system" 	# Title of coordinate system
+#         Naxes = 2 	# Number of coordinate axes
+#         Domain = "ZOOMED" 	# Coordinate system domain
+#         Epoch = 2000 	# Julian epoch of observation
+#         Lbl1 = "Axis 1" 	# Label for axis 1
+#         Lbl2 = "Axis 2" 	# Label for axis 2
+#         System = "Cartesian" 	# Coordinate system type
+       IsA Frame 	# Coordinate system description
+          Adapt = 1 	# Region adapts to coord sys changes
+          Frm = 	# Coordinate system
+             Begin Frame 	# Coordinate system description
+#               Title = "2-d coordinate system" 	# Title of coordinate system
+                Naxes = 2 	# Number of coordinate axes
+                Domain = "ZOOMED" 	# Coordinate system domain
+#               Lbl1 = "Axis 1" 	# Label for axis 1
+#               Lbl2 = "Axis 2" 	# Label for axis 2
+                Ax1 = 	# Axis number 1
+                   Begin Axis 	# Coordinate axis
+                   End Axis
+                Ax2 = 	# Axis number 2
+                   Begin Axis 	# Coordinate axis
+                   End Axis
+             End Frame
+          Points = 	# Points defining the shape
+             Begin PointSet 	# Container for a set of points
+                Npoint = 2 	# Number of points
+                Ncoord = 2 	# Number of coordinates per point
+                X1 = 5 	# Coordinate values...
+                X2 = 5
+                X3 = 10
+                X4 = 10
+             End PointSet
+       IsA Region 	# An area within a coordinate system
+       End Box
+ End SelectorMap

--- a/ast_tester/simplify_fixtures/sph_matrix_sandwich.map
+++ b/ast_tester/simplify_fixtures/sph_matrix_sandwich.map
@@ -6,12 +6,14 @@
        Begin SphMap 	# Cartesian to Spherical mapping
           Nin = 3 	# Number of input coordinates
           Nout = 2 	# Number of output coordinates
+          Invert = 1 	# Mapping inverted
        IsA Mapping 	# Mapping between coordinate systems
           PlrLg = 0 	# Polar longitude (rad.s)
        End SphMap
     MapB = 	# Second component Mapping
        Begin CmpMap 	# Compound Mapping
           Nin = 3 	# Number of input coordinates
+          Nout = 2 	# Number of output coordinates
        IsA Mapping 	# Mapping between coordinate systems
           MapA = 	# First component Mapping
              Begin MatrixMap 	# Matrix transformation

--- a/ast_tester/simplify_fixtures/time_5arg_cancel.map
+++ b/ast_tester/simplify_fixtures/time_5arg_cancel.map
@@ -8,7 +8,7 @@
     Time1c = -2.5 	# Observer latitude
     Time1d = 6378 	# Observer altitude
     Time1e = -5121.0504050301515 	# Distance from earth spin axis
-    Time1f = -3799.9547800119039 	# Distance north of equatorial plane
+    Time1f = -3799.9547800119035 	# Distance north of equatorial plane
     Time1g = 0 	# DTAI
     Time2 = "TDBTOTT" 	# Convert TDB to TT
     Time2a = 53000 	# MJD offset
@@ -16,6 +16,6 @@
     Time2c = -2.5 	# Observer latitude
     Time2d = 6378 	# Observer altitude
     Time2e = -5121.0504050301515 	# Distance from earth spin axis
-    Time2f = -3799.9547800119039 	# Distance north of equatorial plane
+    Time2f = -3799.9547800119035 	# Distance north of equatorial plane
     Time2g = 0 	# DTAI
  End TimeMap

--- a/ast_tester/simplify_tests.txt
+++ b/ast_tester/simplify_tests.txt
@@ -242,3 +242,10 @@ unitnormmap_inv_fwd_cancel | simplify_fixtures/unitnormmap_inv_fwd_cancel.map | 
 perm_outperm_constant_fold | simplify_fixtures/perm_outperm_constant_fold.map | simplify_fixtures/perm_outperm_constant_fold.simp |
 box_parallel_merge      | simplify_fixtures/box_parallel_merge.map      | simplify_fixtures/box_parallel_merge.simp      |
 interval_parallel_merge | simplify_fixtures/interval_parallel_merge.map | simplify_fixtures/interval_parallel_merge.simp |
+box_self_simplify       | simplify_fixtures/box_self_simplify.map       | simplify_fixtures/box_self_simplify.simp       |
+interval_self_simplify  | simplify_fixtures/interval_self_simplify.map  | simplify_fixtures/interval_self_simplify.simp  |
+nullregion_self_simplify | simplify_fixtures/nullregion_self_simplify.map | simplify_fixtures/nullregion_self_simplify.simp |
+nullregion_parallel_merge | simplify_fixtures/nullregion_parallel_merge.map | simplify_fixtures/nullregion_parallel_merge.simp |
+pointlist_self_simplify | simplify_fixtures/pointlist_self_simplify.map | simplify_fixtures/pointlist_self_simplify.simp |
+normmap_frame_simplifies | simplify_fixtures/normmap_frame_simplifies.map | simplify_fixtures/normmap_frame_simplifies.simp |
+selectormap_region_simplify | simplify_fixtures/selectormap_region_simplify.map | simplify_fixtures/selectormap_region_simplify.simp |


### PR DESCRIPTION
Adds three new fixture generators that were possibly not created correctly. The text the AI emitted lacked Mapping-base attributes (Nin / IsA Mapping for inner GrismMaps, Inv for non-inverted RateMaps, Nout for a CmpMap whose internal nout==nin) that canonical C-side astToString output does emit, which left downstream byte-exact round-trip tests chasing implementation-detail "shadow" state instead of reconstructing semantics. Running them through write_fixture() makes them canonical so other ports can match them directly.

- gen_grismmap_fixtures: add grism_zoom_merge (forward GrismMap + ZoomMap series merge) and grism_inverse_cancel (GrismMap + inverted-GrismMap pair with opposite GrmM signs, simplifies to UnitMap). GRISM_PARAMS macro for shared attribute string.
- gen_ratemap_fixtures: add ratemap_inverse_cancel (RateMap + invert(RateMap) over identical ZoomMaps, simplifies to UnitMap).
- gen_sphmap_fixtures: add sph_matrix_sandwich (inv(SphMap) + diagonal-MatrixMap + SphMap, simplifies to a MatrixMap with axis-flipping diagonal). PolarLong=0 explicitly set so the resulting fixture pins PlrLg with the `set` flag (Test == true).

The regenerated fixtures are byte-exact with the C library when built with C11 (`-DAST_C_STANDARD=11`). C99 picks an extra digit of double precision and shifts the last ulp of TimeMap's TT<->TDB derived "v" argument in time_5arg_cancel / neg_time_5arg_mismatch, so this commit also regenerates those two pre-existing fixtures under C11 to bring them in line with the Rust port's output (and with CLAUDE.md's note that serialization tests require C11).

Also captures the seven `*_self_simplify` / region fixtures that gen_simplify_fixtures.c was supposed to emit on this branch but hadn't been run+committed yet (box_self_simplify,
interval_self_simplify, nullregion_self_simplify,
nullregion_parallel_merge, pointlist_self_simplify, normmap_frame_simplifies, selectormap_region_simplify).