### PR TITLE
Experimental optional vectorization for SphMap, PolyMap and MatrixMap

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -16,6 +16,7 @@ jobs:
         shared_libs: [ON, OFF]
         fortran: [OFF]
         sanitizers: [OFF]
+        simd: [OFF]
         include:
           # Add a Fortran build on each platform (shared only)
           - os: ubuntu-latest
@@ -23,22 +24,37 @@ jobs:
             shared_libs: ON
             fortran: ON
             sanitizers: OFF
+            simd: OFF
           - os: macos-latest
             build_type: Release
             shared_libs: ON
             fortran: ON
             sanitizers: OFF
+            simd: OFF
           # Debug builds with sanitizers
           - os: ubuntu-latest
             build_type: Debug
             shared_libs: ON
             fortran: OFF
             sanitizers: ON
+            simd: OFF
           - os: macos-latest
             build_type: Debug
             shared_libs: ON
             fortran: OFF
             sanitizers: ON
+            simd: OFF
+          # SIMD build (Ubuntu + GCC, Release). Exercises AST_ENABLE_SIMD.
+          # The code is compiled for x86-64-v3 (AVX2) with no runtime fallback,
+          # so it needs an AVX2-capable runner; GitHub's hosted x86-64 Linux
+          # runners (AMD EPYC) seem to provide AVX2 in practice; reference:
+          # https://runs-on.com/benchmarks/github-actions-cpu-performance/
+          - os: ubuntu-latest
+            build_type: Release
+            shared_libs: ON
+            fortran: OFF
+            sanitizers: OFF
+            simd: ON
 
     runs-on: ${{ matrix.os }}
 
@@ -62,6 +78,7 @@ jobs:
           -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }}
           -DAST_BUILD_FORTRAN=${{ matrix.fortran }}
           -DAST_ENABLE_SANITIZERS=${{ matrix.sanitizers }}
+          -DAST_ENABLE_SIMD=${{ matrix.simd }}
           -DAST_C_STANDARD=11
 
       - name: Build

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -26,6 +26,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug
           -DBUILD_SHARED_LIBS=OFF
           -DAST_ENABLE_COVERAGE=ON
+          -DAST_ENABLE_SIMD=ON
           -DAST_C_STANDARD=11
 
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ include(CheckIncludeFile)
 include(CheckFunctionExists)
 include(CheckTypeSize)
 include(CheckCSourceCompiles)
+include(CheckCCompilerFlag)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
@@ -33,6 +34,7 @@ option(AST_WITH_MEMDEBUG "Enable AST memory leak debugging" OFF)
 option(AST_ENABLE_WARNINGS "Enable extra compiler warnings for development builds" OFF)
 option(AST_ENABLE_SANITIZERS "Enable address/undefined sanitizers for supported compilers" OFF)
 option(AST_ENABLE_COVERAGE "Enable compiler coverage instrumentation for supported compilers" OFF)
+option(AST_ENABLE_SIMD "Enable SIMD/vectorization via GCC+glibc libmvec" OFF)
 option(AST_ENABLE_HUGE_TEST "Build the huge manual stress test converted from testhuge.f" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(BUILD_TESTING "Build the test program" ON)
@@ -125,6 +127,42 @@ if(AST_ENABLE_COVERAGE)
         )
     else()
         message(WARNING "AST_ENABLE_COVERAGE is ON, but no coverage profile is defined for compiler ${CMAKE_C_COMPILER_ID}")
+    endif()
+endif()
+
+set(AST_SIMD_FLAGS)  # per-file flags for SIMD-vectorized source files
+
+if(AST_ENABLE_SIMD)
+    if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+        check_c_compiler_flag(-fopenmp-simd    HAVE_FOPENMP_SIMD)
+        check_c_compiler_flag(-ffast-math      HAVE_FFAST_MATH)
+        check_c_compiler_flag(-march=x86-64-v3 HAVE_MARCH_X86_64_V3)
+
+        if(HAVE_FOPENMP_SIMD AND HAVE_FFAST_MATH AND HAVE_MARCH_X86_64_V3)
+            # -fopenmp-simd enables #pragma omp simd; -ffast-math is required
+            # for libmvec trig dispatch (sphmap.c) and improves vectorization
+            # of arithmetic loops (polymap.c).  -fno-associative-math is added
+            # back to avoid FMA-based reassociation changing other arithmetic.
+            list(APPEND AST_SIMD_FLAGS
+                -fopenmp-simd
+                -ffast-math
+                -fno-associative-math
+                -march=x86-64-v3
+            )
+            message(STATUS
+                "AST SIMD: GCC+libmvec vectorization enabled for sphmap.c, polymap.c, "
+                "matrixmap.c (${AST_SIMD_FLAGS})")
+        else()
+            message(WARNING
+                "AST_ENABLE_SIMD is ON but required flags are not available: "
+                "-fopenmp-simd=${HAVE_FOPENMP_SIMD} "
+                "-ffast-math=${HAVE_FFAST_MATH} "
+                "-march=x86-64-v3=${HAVE_MARCH_X86_64_V3}")
+        endif()
+    else()
+        message(WARNING
+            "AST_ENABLE_SIMD is ON but is only supported with GCC on glibc systems "
+            "(compiler: ${CMAKE_C_COMPILER_ID})")
     endif()
 endif()
 
@@ -750,6 +788,15 @@ set_target_properties(ast PROPERTIES
 )
 ast_apply_dev_options(ast)
 
+# Apply SIMD flags to specific source files only (not the whole library) so
+# that -ffast-math and -march= do not change the FP semantics of the rest of
+# libast. AST_HAVE_SIMD guards the restructured loops inside those files.
+if(AST_SIMD_FLAGS)
+    set_source_files_properties(src/sphmap.c src/polymap.c src/matrixmap.c
+        PROPERTIES COMPILE_OPTIONS "${AST_SIMD_FLAGS}")
+    target_compile_definitions(ast PRIVATE AST_HAVE_SIMD=1)
+endif()
+
 # libast references symbols (astGFlush, astPutErr_, etc.) that are provided
 # by the satellite libraries (ast_err, ast_grf_*). These are intentionally
 # unresolved in libast and resolved at final link time. Allow this.
@@ -901,6 +948,7 @@ if(BUILD_TESTING)
     ast_apply_dev_options(ast_test)
     add_test(NAME ast_test COMMAND ast_test)
     add_subdirectory(ast_tester)
+    add_subdirectory(perf)
 
     if(AST_ENABLE_COVERAGE)
         if(CMAKE_C_COMPILER_ID STREQUAL "GNU")

--- a/Makefile.am
+++ b/Makefile.am
@@ -30,7 +30,6 @@ GRP_C_ROUTINES = \
     src/lutmap.c \
     src/mapping.c \
     src/mathmap.c \
-    src/matrixmap.c \
     src/memory.c \
     src/moc.c \
     src/mocchan.c \
@@ -44,7 +43,6 @@ GRP_C_ROUTINES = \
     src/pointlist.c \
     src/pointset.c \
     src/polygon.c \
-    src/polymap.c \
     src/prism.c \
     src/ratemap.c \
     src/region.c \
@@ -56,7 +54,6 @@ GRP_C_ROUTINES = \
     src/specfluxframe.c \
     src/specframe.c \
     src/specmap.c \
-    src/sphmap.c \
     src/splinemap.c \
     src/stc.c \
     src/stccatalogentrylocation.c \
@@ -585,6 +582,29 @@ CMINPACK_FILES = \
     cminpack/lmpar.c \
     cminpack/qrsolv.c
 
+
+# sphmap.c, polymap.c, and matrixmap.c are compiled as noinst convenience
+# libraries so that per-file SIMD flags (from configure --enable-simd) can
+# be applied without affecting the rest of libast.  When SIMD is not enabled,
+# AST_SIMD_FLAGS is empty.
+AST_MAYBE_SIMD_LIBS = libast_sphmap.la libast_polymap.la libast_matrixmap.la
+noinst_LTLIBRARIES = $(AST_MAYBE_SIMD_LIBS)
+
+libast_polymap_la_SOURCES = src/polymap.c
+libast_sphmap_la_SOURCES = src/sphmap.c
+libast_matrixmap_la_SOURCES = src/matrixmap.c
+
+if !NOPIC
+libast_polymap_la_CFLAGS = $(AM_CFLAGS) -prefer-pic $(threadsafe) $(yaml) @AST_SIMD_FLAGS@
+libast_sphmap_la_CFLAGS = $(AM_CFLAGS) -prefer-pic $(threadsafe) $(yaml) @AST_SIMD_FLAGS@
+libast_matrixmap_la_CFLAGS = $(AM_CFLAGS) -prefer-pic $(threadsafe) $(yaml) @AST_SIMD_FLAGS@
+else
+libast_polymap_la_CFLAGS = $(AM_CFLAGS) $(threadsafe) $(yaml) @AST_SIMD_FLAGS@
+libast_sphmap_la_CFLAGS = $(AM_CFLAGS) $(threadsafe) $(yaml) @AST_SIMD_FLAGS@
+libast_matrixmap_la_CFLAGS = $(AM_CFLAGS) $(threadsafe) $(yaml) @AST_SIMD_FLAGS@
+endif
+
+
 bin_SCRIPTS = ast_link
 dist_bin_SCRIPTS = ast_link_adam
 noinst_SCRIPTS = ast_cpp
@@ -712,15 +732,15 @@ libast_la_LDFLAGS = -version-info @version_info@
 # library instead. Do the same for cminpack
 if EXTERNAL_PAL
 if EXTERNAL_CMINPACK
-libast_la_LIBADD =  -lpal -lcminpack
+libast_la_LIBADD =  -lpal -lcminpack $(AST_MAYBE_SIMD_LIBS)
 else
-libast_la_LIBADD = -lpal libast_cminpack.la
+libast_la_LIBADD = -lpal libast_cminpack.la $(AST_MAYBE_SIMD_LIBS)
 endif
 else
 if EXTERNAL_CMINPACK
-libast_la_LIBADD =  libast_pal.la -lcminpack
+libast_la_LIBADD =  libast_pal.la -lcminpack $(AST_MAYBE_SIMD_LIBS)
 else
-libast_la_LIBADD = libast_pal.la libast_cminpack.la
+libast_la_LIBADD = libast_pal.la libast_cminpack.la $(AST_MAYBE_SIMD_LIBS)
 endif
 endif
 

--- a/ast_tester/CMakeLists.txt
+++ b/ast_tester/CMakeLists.txt
@@ -408,7 +408,7 @@ ast_add_test(testgrid
 target_include_directories(testgrid PRIVATE "${CMAKE_SOURCE_DIR}/src")
 
 function(add_grid_test)
-    cmake_parse_arguments(P "SKIP_TEXT_COMPARE;NO_SIMD"
+    cmake_parse_arguments(P "SKIP_TEXT_COMPARE"
         "NAME;HEAD;ATTR;FATTR;BOX;REFERENCE"
         ""
         ${ARGN})
@@ -437,14 +437,6 @@ function(add_grid_test)
         set(_ref_arg "-DREF_FILE=${P_REFERENCE}")
     endif()
 
-    # NO_SIMD disables SIMD on the WCS SphMaps for this test.  Required when
-    # a few ULP libmvec/scalar math differences shift label pixel positions and
-    # break the text-label comparison against the committed reference.
-    set(_nosimd_arg "")
-    if(P_NO_SIMD)
-        set(_nosimd_arg "-DNO_SIMD=ON")
-    endif()
-
     add_test(NAME grid_${P_NAME}
         COMMAND ${CMAKE_COMMAND}
             -DTESTGRID=$<TARGET_FILE:testgrid>
@@ -454,7 +446,6 @@ function(add_grid_test)
             -DOUT_FILE=grid_${P_NAME}.svg
             "${_ref_arg}"
             "-DBOX=${_box_arg}"
-            "${_nosimd_arg}"
             -P "${CMAKE_SOURCE_DIR}/cmake/run_grid_test.cmake"
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
     if(AST_ENABLE_SANITIZERS)
@@ -463,7 +454,7 @@ function(add_grid_test)
     endif()
 endfunction()
 
-ast_read_test_data("${CMAKE_CURRENT_SOURCE_DIR}/grid_tests.txt" _grid_tests 8)
+ast_read_test_data("${CMAKE_CURRENT_SOURCE_DIR}/grid_tests.txt" _grid_tests 7)
 foreach(_entry IN LISTS _grid_tests)
     string(REPLACE "|" ";" _fields "${_entry}")
     list(GET _fields 0 _name)
@@ -473,7 +464,6 @@ foreach(_entry IN LISTS _grid_tests)
     list(GET _fields 4 _box)
     list(GET _fields 5 _reference)
     list(GET _fields 6 _skip)
-    list(GET _fields 7 _no_simd)
     set(_args "NAME" "${_name}" "HEAD" "${_head}")
     if(NOT _attr STREQUAL "")
         list(APPEND _args "ATTR" "${_attr}")
@@ -489,9 +479,6 @@ foreach(_entry IN LISTS _grid_tests)
     endif()
     if(_skip STREQUAL "yes")
         list(APPEND _args "SKIP_TEXT_COMPARE")
-    endif()
-    if(_no_simd STREQUAL "yes")
-        list(APPEND _args "NO_SIMD")
     endif()
     add_grid_test(${_args})
 endforeach()
@@ -610,7 +597,7 @@ if(PLPLOT_FOUND)
         endif()
     endfunction()
 
-    ast_read_test_data("${CMAKE_CURRENT_SOURCE_DIR}/grid_tests.txt" _plotter_tests 8)
+    ast_read_test_data("${CMAKE_CURRENT_SOURCE_DIR}/grid_tests.txt" _plotter_tests 7)
     foreach(_entry IN LISTS _plotter_tests)
         string(REPLACE "|" ";" _fields "${_entry}")
         list(GET _fields 0 _name)

--- a/ast_tester/CMakeLists.txt
+++ b/ast_tester/CMakeLists.txt
@@ -408,7 +408,7 @@ ast_add_test(testgrid
 target_include_directories(testgrid PRIVATE "${CMAKE_SOURCE_DIR}/src")
 
 function(add_grid_test)
-    cmake_parse_arguments(P "SKIP_TEXT_COMPARE"
+    cmake_parse_arguments(P "SKIP_TEXT_COMPARE;NO_SIMD"
         "NAME;HEAD;ATTR;FATTR;BOX;REFERENCE"
         ""
         ${ARGN})
@@ -437,6 +437,14 @@ function(add_grid_test)
         set(_ref_arg "-DREF_FILE=${P_REFERENCE}")
     endif()
 
+    # NO_SIMD disables SIMD on the WCS SphMaps for this test.  Required when
+    # a few ULP libmvec/scalar math differences shift label pixel positions and
+    # break the text-label comparison against the committed reference.
+    set(_nosimd_arg "")
+    if(P_NO_SIMD)
+        set(_nosimd_arg "-DNO_SIMD=ON")
+    endif()
+
     add_test(NAME grid_${P_NAME}
         COMMAND ${CMAKE_COMMAND}
             -DTESTGRID=$<TARGET_FILE:testgrid>
@@ -446,6 +454,7 @@ function(add_grid_test)
             -DOUT_FILE=grid_${P_NAME}.svg
             "${_ref_arg}"
             "-DBOX=${_box_arg}"
+            "${_nosimd_arg}"
             -P "${CMAKE_SOURCE_DIR}/cmake/run_grid_test.cmake"
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
     if(AST_ENABLE_SANITIZERS)
@@ -454,7 +463,7 @@ function(add_grid_test)
     endif()
 endfunction()
 
-ast_read_test_data("${CMAKE_CURRENT_SOURCE_DIR}/grid_tests.txt" _grid_tests 7)
+ast_read_test_data("${CMAKE_CURRENT_SOURCE_DIR}/grid_tests.txt" _grid_tests 8)
 foreach(_entry IN LISTS _grid_tests)
     string(REPLACE "|" ";" _fields "${_entry}")
     list(GET _fields 0 _name)
@@ -464,6 +473,7 @@ foreach(_entry IN LISTS _grid_tests)
     list(GET _fields 4 _box)
     list(GET _fields 5 _reference)
     list(GET _fields 6 _skip)
+    list(GET _fields 7 _no_simd)
     set(_args "NAME" "${_name}" "HEAD" "${_head}")
     if(NOT _attr STREQUAL "")
         list(APPEND _args "ATTR" "${_attr}")
@@ -479,6 +489,9 @@ foreach(_entry IN LISTS _grid_tests)
     endif()
     if(_skip STREQUAL "yes")
         list(APPEND _args "SKIP_TEXT_COMPARE")
+    endif()
+    if(_no_simd STREQUAL "yes")
+        list(APPEND _args "NO_SIMD")
     endif()
     add_grid_test(${_args})
 endforeach()
@@ -597,7 +610,7 @@ if(PLPLOT_FOUND)
         endif()
     endfunction()
 
-    ast_read_test_data("${CMAKE_CURRENT_SOURCE_DIR}/grid_tests.txt" _plotter_tests 7)
+    ast_read_test_data("${CMAKE_CURRENT_SOURCE_DIR}/grid_tests.txt" _plotter_tests 8)
     foreach(_entry IN LISTS _plotter_tests)
         string(REPLACE "|" ";" _fields "${_entry}")
         list(GET _fields 0 _name)

--- a/ast_tester/CMakeLists.txt
+++ b/ast_tester/CMakeLists.txt
@@ -134,6 +134,7 @@ configure_file(splittest1.ast "${CMAKE_CURRENT_BINARY_DIR}/splittest1.ast" COPYO
 ast_add_test(testcmpmap)
 ast_add_test(testpolymap)
 ast_add_test(testchebymap)
+ast_add_test(testsimd)
 ast_add_test(testunitnormmap_c SOURCES testunitnormmap.c)
 ast_add_test(testtrangrid)
 ast_add_test(testmoc)

--- a/ast_tester/grid_tests.txt
+++ b/ast_tester/grid_tests.txt
@@ -1,27 +1,26 @@
 # Grid and plotter smoke tests -- pipe-delimited
 # Shared by both grid_ (unconditional, logging GRF) and plotter_ (PLplot) tests.
-# Fields: name | head | attr | fattr | box | reference | skip_text_compare | no_simd
+# Fields: name | head | attr | fattr | box | reference | skip_text_compare
 # reference: .svg file for text-label regression diff (grid_ tests only)
 # skip_text_compare: "yes" = smoke-only, no label comparison (half-integer
 #                    degree boundary causes 1-ULP formatting instability)
-# no_simd: "yes" = run testgrid with --no-simd (disable SIMD on supported transforms)
-aitoff   | aitoff.head   | Grid=1,tickall=0,border=1,tol=0.001                                                  |          | 10.0 -10.0 300.0 280.0  | aitoff.svg   |     |
-car1     | car1.head     | numlabgap=0.05                                                                       | carlin=1 | 0 0 2962 562             | car1.svg     |     |
-car2     | car2.head     | numlabgap(2)=0.05,labelling=interior                                                  | carlin=1 | 0 0 2962 562             | car2.svg     |     |
-car3     | car3.head     | grid=1                                                                                |          | 0 0 400 400              | car3.svg     |     | yes
-car4     | car4.head     | format(1)=gd,format(2)=gd,Grid=1,tickall=0,width(axes)=3                              | carlin=1 | 0 0 951 1851             | car4.svg     | yes |
-car5     | car5.head     | border=1                                                                              |          | 0 0 951 1851             | car5.svg     |     |
-car6     | car6.head     | format(1)=ghms,format(2)=gdm,edge(2)=r,tickall=0,grid=1                               |          | 0 0 5401 1741            | car6.svg     |     |
-cobe     | cobe.head     | Grid=0,labelling=exterior,gap(1)=50                                                   |          | 10.0 -10.0 300.0 280.0  | cobe.svg     |     |
-hpx      | hpx.head      | Grid=1,labelling=interior,bottom(1)=0                                                 |          | 0.5 0.5 300.5 200.5     | hpx.svg      |     |
-origin   | origin.head   | Grid=1,labelling=int                                                                  |          | 0 0 500 500              | origin.svg   |     |
-polco    | polco.head    | border=1                                                                              |          | -300 -300 500 500        | polco.svg    |     |
-polco2   | polco2.head   |                                                                                       |          | -300 -300 500 500        | polco2.svg   |     |
-scp      | scp.head      | border=1                                                                              |          | 1.0 1.0 1500.0 1300.0   | scp.svg      |     |
-serpens   | serpens.head  |                                                                                       |          | 0.5 0.5 150.5 120.5     | serpens.svg  |     |
-specflux | specflux.head | system=freq,logplot=1,loggap(1)=100                                                   |          | 1 3 1.0E-8 9            | specflux.svg |     |
-timeplot | timeplot.head | minticklen=0.02,majticklen=0.05,gap(2)=0.1,NumLabGap=0.05,textlabgap=0.1,size=0.9    |          | 0.046 3.0 1.008 3.3     | timeplot.svg |     |
-tnx      | tnx.head      | Grid=1,textlabgap=0.1,border=0                                                       |          | 0.0 0.0 2048.0 4096.0   | tnx.svg      |     |
-tsc      | tsc.head      | border=1                                                                              |          | 1 1 1600 1600            | tsc.svg      |     |
-zpn      | zpn.head      | tol=0.0001                                                                           |          | 1 1 200.0 200.0          | zpn.svg      |     |
-zpx      | zpx.head      | Grid=1,style(grid1)=2,size(textlab2)=2                                                |          |                          | zpx.svg      |     |
+aitoff   | aitoff.head   | Grid=1,tickall=0,border=1,tol=0.001                                                  |          | 10.0 -10.0 300.0 280.0  | aitoff.svg   |
+car1     | car1.head     | numlabgap=0.05                                                                       | carlin=1 | 0 0 2962 562             | car1.svg     |
+car2     | car2.head     | numlabgap(2)=0.05,labelling=interior                                                  | carlin=1 | 0 0 2962 562             | car2.svg     |
+car3     | car3.head     | grid=1                                                                                |          | 0 0 400 400              | car3.svg     |
+car4     | car4.head     | format(1)=gd,format(2)=gd,Grid=1,tickall=0,width(axes)=3                              | carlin=1 | 0 0 951 1851             | car4.svg     | yes
+car5     | car5.head     | border=1                                                                              |          | 0 0 951 1851             | car5.svg     |
+car6     | car6.head     | format(1)=ghms,format(2)=gdm,edge(2)=r,tickall=0,grid=1                               |          | 0 0 5401 1741            | car6.svg     |
+cobe     | cobe.head     | Grid=0,labelling=exterior,gap(1)=50                                                   |          | 10.0 -10.0 300.0 280.0  | cobe.svg     |
+hpx      | hpx.head      | Grid=1,labelling=interior,bottom(1)=0                                                 |          | 0.5 0.5 300.5 200.5     | hpx.svg      |
+origin   | origin.head   | Grid=1,labelling=int                                                                  |          | 0 0 500 500              | origin.svg   |
+polco    | polco.head    | border=1                                                                              |          | -300 -300 500 500        | polco.svg    |
+polco2   | polco2.head   |                                                                                       |          | -300 -300 500 500        | polco2.svg   |
+scp      | scp.head      | border=1                                                                              |          | 1.0 1.0 1500.0 1300.0   | scp.svg      |
+serpens   | serpens.head  |                                                                                       |          | 0.5 0.5 150.5 120.5     | serpens.svg  |
+specflux | specflux.head | system=freq,logplot=1,loggap(1)=100                                                   |          | 1 3 1.0E-8 9            | specflux.svg |
+timeplot | timeplot.head | minticklen=0.02,majticklen=0.05,gap(2)=0.1,NumLabGap=0.05,textlabgap=0.1,size=0.9    |          | 0.046 3.0 1.008 3.3     | timeplot.svg |
+tnx      | tnx.head      | Grid=1,textlabgap=0.1,border=0                                                       |          | 0.0 0.0 2048.0 4096.0   | tnx.svg      |
+tsc      | tsc.head      | border=1                                                                              |          | 1 1 1600 1600            | tsc.svg      |
+zpn      | zpn.head      | tol=0.0001                                                                           |          | 1 1 200.0 200.0          | zpn.svg      |
+zpx      | zpx.head      | Grid=1,style(grid1)=2,size(textlab2)=2                                                |          |                          | zpx.svg      |

--- a/ast_tester/grid_tests.txt
+++ b/ast_tester/grid_tests.txt
@@ -1,26 +1,27 @@
 # Grid and plotter smoke tests -- pipe-delimited
 # Shared by both grid_ (unconditional, logging GRF) and plotter_ (PLplot) tests.
-# Fields: name | head | attr | fattr | box | reference | skip_text_compare
+# Fields: name | head | attr | fattr | box | reference | skip_text_compare | no_simd
 # reference: .svg file for text-label regression diff (grid_ tests only)
 # skip_text_compare: "yes" = smoke-only, no label comparison (half-integer
 #                    degree boundary causes 1-ULP formatting instability)
-aitoff   | aitoff.head   | Grid=1,tickall=0,border=1,tol=0.001                                                  |          | 10.0 -10.0 300.0 280.0  | aitoff.svg   |
-car1     | car1.head     | numlabgap=0.05                                                                       | carlin=1 | 0 0 2962 562             | car1.svg     |
-car2     | car2.head     | numlabgap(2)=0.05,labelling=interior                                                  | carlin=1 | 0 0 2962 562             | car2.svg     |
-car3     | car3.head     | grid=1                                                                                |          | 0 0 400 400              | car3.svg     |
-car4     | car4.head     | format(1)=gd,format(2)=gd,Grid=1,tickall=0,width(axes)=3                              | carlin=1 | 0 0 951 1851             | car4.svg     | yes
-car5     | car5.head     | border=1                                                                              |          | 0 0 951 1851             | car5.svg     |
-car6     | car6.head     | format(1)=ghms,format(2)=gdm,edge(2)=r,tickall=0,grid=1                               |          | 0 0 5401 1741            | car6.svg     |
-cobe     | cobe.head     | Grid=0,labelling=exterior,gap(1)=50                                                   |          | 10.0 -10.0 300.0 280.0  | cobe.svg     |
-hpx      | hpx.head      | Grid=1,labelling=interior,bottom(1)=0                                                 |          | 0.5 0.5 300.5 200.5     | hpx.svg      |
-origin   | origin.head   | Grid=1,labelling=int                                                                  |          | 0 0 500 500              | origin.svg   |
-polco    | polco.head    | border=1                                                                              |          | -300 -300 500 500        | polco.svg    |
-polco2   | polco2.head   |                                                                                       |          | -300 -300 500 500        | polco2.svg   |
-scp      | scp.head      | border=1                                                                              |          | 1.0 1.0 1500.0 1300.0   | scp.svg      |
-serpens   | serpens.head  |                                                                                       |          | 0.5 0.5 150.5 120.5     | serpens.svg  |
-specflux | specflux.head | system=freq,logplot=1,loggap(1)=100                                                   |          | 1 3 1.0E-8 9            | specflux.svg |
-timeplot | timeplot.head | minticklen=0.02,majticklen=0.05,gap(2)=0.1,NumLabGap=0.05,textlabgap=0.1,size=0.9    |          | 0.046 3.0 1.008 3.3     | timeplot.svg |
-tnx      | tnx.head      | Grid=1,textlabgap=0.1,border=0                                                       |          | 0.0 0.0 2048.0 4096.0   | tnx.svg      |
-tsc      | tsc.head      | border=1                                                                              |          | 1 1 1600 1600            | tsc.svg      |
-zpn      | zpn.head      | tol=0.0001                                                                           |          | 1 1 200.0 200.0          | zpn.svg      |
-zpx      | zpx.head      | Grid=1,style(grid1)=2,size(textlab2)=2                                                |          |                          | zpx.svg      |
+# no_simd: "yes" = run testgrid with --no-simd (disable SIMD on supported transforms)
+aitoff   | aitoff.head   | Grid=1,tickall=0,border=1,tol=0.001                                                  |          | 10.0 -10.0 300.0 280.0  | aitoff.svg   |     |
+car1     | car1.head     | numlabgap=0.05                                                                       | carlin=1 | 0 0 2962 562             | car1.svg     |     |
+car2     | car2.head     | numlabgap(2)=0.05,labelling=interior                                                  | carlin=1 | 0 0 2962 562             | car2.svg     |     |
+car3     | car3.head     | grid=1                                                                                |          | 0 0 400 400              | car3.svg     |     | yes
+car4     | car4.head     | format(1)=gd,format(2)=gd,Grid=1,tickall=0,width(axes)=3                              | carlin=1 | 0 0 951 1851             | car4.svg     | yes |
+car5     | car5.head     | border=1                                                                              |          | 0 0 951 1851             | car5.svg     |     |
+car6     | car6.head     | format(1)=ghms,format(2)=gdm,edge(2)=r,tickall=0,grid=1                               |          | 0 0 5401 1741            | car6.svg     |     |
+cobe     | cobe.head     | Grid=0,labelling=exterior,gap(1)=50                                                   |          | 10.0 -10.0 300.0 280.0  | cobe.svg     |     |
+hpx      | hpx.head      | Grid=1,labelling=interior,bottom(1)=0                                                 |          | 0.5 0.5 300.5 200.5     | hpx.svg      |     |
+origin   | origin.head   | Grid=1,labelling=int                                                                  |          | 0 0 500 500              | origin.svg   |     |
+polco    | polco.head    | border=1                                                                              |          | -300 -300 500 500        | polco.svg    |     |
+polco2   | polco2.head   |                                                                                       |          | -300 -300 500 500        | polco2.svg   |     |
+scp      | scp.head      | border=1                                                                              |          | 1.0 1.0 1500.0 1300.0   | scp.svg      |     |
+serpens   | serpens.head  |                                                                                       |          | 0.5 0.5 150.5 120.5     | serpens.svg  |     |
+specflux | specflux.head | system=freq,logplot=1,loggap(1)=100                                                   |          | 1 3 1.0E-8 9            | specflux.svg |     |
+timeplot | timeplot.head | minticklen=0.02,majticklen=0.05,gap(2)=0.1,NumLabGap=0.05,textlabgap=0.1,size=0.9    |          | 0.046 3.0 1.008 3.3     | timeplot.svg |     |
+tnx      | tnx.head      | Grid=1,textlabgap=0.1,border=0                                                       |          | 0.0 0.0 2048.0 4096.0   | tnx.svg      |     |
+tsc      | tsc.head      | border=1                                                                              |          | 1 1 1600 1600            | tsc.svg      |     |
+zpn      | zpn.head      | tol=0.0001                                                                           |          | 1 1 200.0 200.0          | zpn.svg      |     |
+zpx      | zpx.head      | Grid=1,style(grid1)=2,size(textlab2)=2                                                |          |                          | zpx.svg      |     |

--- a/ast_tester/testgrid.c
+++ b/ast_tester/testgrid.c
@@ -7,12 +7,19 @@
 *     with no external graphics library dependency.
 *
 *  Usage:
-*     testgrid <fits file> <attr> <fattr> [<outfile>] [<xlo> <ylo> <xhi> <yhi>]
+*     testgrid [--no-simd] <fits file> <attr> <fattr> [<outfile>] [<xlo> <ylo> <xhi> <yhi>]
 *
 *     If <outfile> is "-" or omitted, no output is written (smoke-test
 *     mode).  If a path ending in ".svg" is given, an SVG image is
 *     produced.  Otherwise a GRF call log is written for regression
 *     testing.
+*
+*     --no-simd (or -S) disables SIMD on any SphMap in the WCS mapping
+*     before plotting.  The 1-ULP differences between libmvec vector math
+*     and scalar libm shift a few integer pixel label positions by 1 px,
+*     which makes the SVG output differ from the committed reference for
+*     some projections (e.g. car3).  Disabling SIMD restores bit-for-bit
+*     agreement with the scalar reference.
 *
 *  Description:
 *     Reads a FITS header from <fits file>, builds a FrameSet via
@@ -34,6 +41,39 @@
 #include "ast.h"
 #include "grf_log.h"
 
+/* Recursively walk a (possibly compound) Mapping and set UseSIMD=0 on every
+   component that has a SIMD-vectorised transform (SphMap, PolyMap, MatrixMap),
+   so the whole pipeline matches the scalar reference bit-for-bit.
+
+   Too bad astMapList isn't part of the public API; it might be nice to have
+   for cases like this. */
+static void disableSimd( AstMapping *map ) {
+   AstMapping *map1 = NULL;
+   AstMapping *map2 = NULL;
+   int series, inv1, inv2;
+
+   if( !astOK || map == AST__NULL )
+      return;
+
+   if( astIsASphMap( map ) || astIsAPolyMap( map ) || astIsAMatrixMap( map ) ) {
+      astSet( map, "UseSIMD=0" );
+      return;
+   }
+
+   astDecompose( map, &map1, &map2, &series, &inv1, &inv2 );
+
+   if( map2 != AST__NULL ) {
+      disableSimd( map1 );
+      disableSimd( map2 );
+   }
+
+   if( map1 != AST__NULL )
+      map1 = astAnnul( map1 );
+
+   if( map2 != AST__NULL )
+      map2 = astAnnul( map2 );
+}
+
 int main( int argc, char **argv ) {
    int status = 0;
    AstFitsChan *fc;
@@ -49,8 +89,18 @@ int main( int argc, char **argv ) {
    float delta, asp;
    int naxis1 = 100, naxis2 = 100;
    int arg_offset;
+   int no_simd = 0;
 
    astWatch( &status );
+
+   /* Optional leading --no-simd / -S flag.  Shift argv so the remaining
+      positional argument handling is unchanged. */
+   if( argc > 1 && ( strcmp( argv[1], "--no-simd" ) == 0 ||
+                     strcmp( argv[1], "-S" ) == 0 ) ) {
+      no_simd = 1;
+      argv++;
+      argc--;
+   }
 
    if( argc < 4 ) {
       printf( "Usage: testgrid <fits file> <attrs> <fattrs> "
@@ -148,6 +198,28 @@ int main( int argc, char **argv ) {
       astGrfLogClose();
       if( logfp ) fclose( logfp );
       return 1;
+   }
+
+   /* Optionally disable SIMD on the base->current mapping.  astGetMapping
+      returns a copy of the mapping, so we set UseSIMD=0 on the SIMD-capable
+      components in that copy and rebuild the FrameSet around it; the value is
+      preserved when the Plot subsequently copies the FrameSet. */
+   if( no_simd && astOK ) {
+      AstFrame *bfrm = astGetFrame( fs, AST__BASE );
+      AstFrame *cfrm = astGetFrame( fs, AST__CURRENT );
+      AstMapping *map = astGetMapping( fs, AST__BASE, AST__CURRENT );
+      AstFrameSet *nfs;
+
+      disableSimd( map );
+
+      nfs = astFrameSet( bfrm, " " );
+      astAddFrame( nfs, AST__BASE, map, cfrm );
+      (void) astAnnul( fs );
+      fs = nfs;
+
+      bfrm = astAnnul( bfrm );
+      cfrm = astAnnul( cfrm );
+      map = astAnnul( map );
    }
 
    if( astOK ) {

--- a/ast_tester/testgrid.c
+++ b/ast_tester/testgrid.c
@@ -7,19 +7,12 @@
 *     with no external graphics library dependency.
 *
 *  Usage:
-*     testgrid [--no-simd] <fits file> <attr> <fattr> [<outfile>] [<xlo> <ylo> <xhi> <yhi>]
+*     testgrid <fits file> <attr> <fattr> [<outfile>] [<xlo> <ylo> <xhi> <yhi>]
 *
 *     If <outfile> is "-" or omitted, no output is written (smoke-test
 *     mode).  If a path ending in ".svg" is given, an SVG image is
 *     produced.  Otherwise a GRF call log is written for regression
 *     testing.
-*
-*     --no-simd (or -S) disables SIMD on any SphMap in the WCS mapping
-*     before plotting.  The 1-ULP differences between libmvec vector math
-*     and scalar libm shift a few integer pixel label positions by 1 px,
-*     which makes the SVG output differ from the committed reference for
-*     some projections (e.g. car3).  Disabling SIMD restores bit-for-bit
-*     agreement with the scalar reference.
 *
 *  Description:
 *     Reads a FITS header from <fits file>, builds a FrameSet via
@@ -41,39 +34,6 @@
 #include "ast.h"
 #include "grf_log.h"
 
-/* Recursively walk a (possibly compound) Mapping and set UseSIMD=0 on every
-   component that has a SIMD-vectorised transform (SphMap, PolyMap, MatrixMap),
-   so the whole pipeline matches the scalar reference bit-for-bit.
-
-   Too bad astMapList isn't part of the public API; it might be nice to have
-   for cases like this. */
-static void disableSimd( AstMapping *map ) {
-   AstMapping *map1 = NULL;
-   AstMapping *map2 = NULL;
-   int series, inv1, inv2;
-
-   if( !astOK || map == AST__NULL )
-      return;
-
-   if( astIsASphMap( map ) || astIsAPolyMap( map ) || astIsAMatrixMap( map ) ) {
-      astSet( map, "UseSIMD=0" );
-      return;
-   }
-
-   astDecompose( map, &map1, &map2, &series, &inv1, &inv2 );
-
-   if( map2 != AST__NULL ) {
-      disableSimd( map1 );
-      disableSimd( map2 );
-   }
-
-   if( map1 != AST__NULL )
-      map1 = astAnnul( map1 );
-
-   if( map2 != AST__NULL )
-      map2 = astAnnul( map2 );
-}
-
 int main( int argc, char **argv ) {
    int status = 0;
    AstFitsChan *fc;
@@ -89,18 +49,8 @@ int main( int argc, char **argv ) {
    float delta, asp;
    int naxis1 = 100, naxis2 = 100;
    int arg_offset;
-   int no_simd = 0;
 
    astWatch( &status );
-
-   /* Optional leading --no-simd / -S flag.  Shift argv so the remaining
-      positional argument handling is unchanged. */
-   if( argc > 1 && ( strcmp( argv[1], "--no-simd" ) == 0 ||
-                     strcmp( argv[1], "-S" ) == 0 ) ) {
-      no_simd = 1;
-      argv++;
-      argc--;
-   }
 
    if( argc < 4 ) {
       printf( "Usage: testgrid <fits file> <attrs> <fattrs> "
@@ -198,28 +148,6 @@ int main( int argc, char **argv ) {
       astGrfLogClose();
       if( logfp ) fclose( logfp );
       return 1;
-   }
-
-   /* Optionally disable SIMD on the base->current mapping.  astGetMapping
-      returns a copy of the mapping, so we set UseSIMD=0 on the SIMD-capable
-      components in that copy and rebuild the FrameSet around it; the value is
-      preserved when the Plot subsequently copies the FrameSet. */
-   if( no_simd && astOK ) {
-      AstFrame *bfrm = astGetFrame( fs, AST__BASE );
-      AstFrame *cfrm = astGetFrame( fs, AST__CURRENT );
-      AstMapping *map = astGetMapping( fs, AST__BASE, AST__CURRENT );
-      AstFrameSet *nfs;
-
-      disableSimd( map );
-
-      nfs = astFrameSet( bfrm, " " );
-      astAddFrame( nfs, AST__BASE, map, cfrm );
-      (void) astAnnul( fs );
-      fs = nfs;
-
-      bfrm = astAnnul( bfrm );
-      cfrm = astAnnul( cfrm );
-      map = astAnnul( map );
    }
 
    if( astOK ) {

--- a/ast_tester/testsimd.c
+++ b/ast_tester/testsimd.c
@@ -1,0 +1,207 @@
+/*
+ *  Test the UseSIMD attribute shared by the PolyMap, SphMap and MatrixMap
+ *  classes (and others to follow).  This attribute selects between the
+ *  SIMD-vectorised and scalar transform code paths at run time.
+ *
+ *  For each class we exercise the attribute accessors (set, get, test, clear)
+ *  and run a transform with UseSIMD=0 to drive the scalar fall-back path,
+ *  checking it produces correct results.  We deliberately do not assert any
+ *  numerical difference between the SIMD and scalar paths: by design they
+ *  agree to within a few ULP, so such an assertion would be both meaningless
+ *  and fragile.
+ */
+#include "ast.h"
+#include <stdio.h>
+#include <math.h>
+
+static void stopit( int i, int *status ) {
+   if( *status != 0 ) return;
+   printf( "Error %d\n", i );
+   *status = 1;
+}
+
+/* Exercise the UseSIMD attribute accessors on the supplied Mapping.  Error
+   codes are offset by "base" so failures identify the class under test. */
+static void check_usesimd( AstMapping *map, int base, int *status ) {
+   int have_simd;
+
+   if( !astOK )
+      return;
+
+/* The value reported when the attribute is unset reflects whether SIMD
+   support was compiled in: 1 if so, 0 otherwise.  Read it first so the
+   remaining checks work in both kinds of build. */
+   have_simd = astGetI( map, "UseSIMD" );
+   if( astTest( map, "UseSIMD" ) ) {
+      stopit( base + 1, status ); /* LCOV_EXCL_LINE */
+   }
+
+/* Disabling is always permitted and persists. */
+   astSetI( map, "UseSIMD", 0 );
+   if( astGetI( map, "UseSIMD" ) != 0 ) {
+      stopit( base + 2, status ); /* LCOV_EXCL_LINE */
+   }
+   if( !astTest( map, "UseSIMD" ) ) {
+      stopit( base + 3, status ); /* LCOV_EXCL_LINE */
+   }
+
+/* In a SIMD build, any non-zero value normalises to 1.  In a non-SIMD build,
+   enabling SIMD is not possible and should report an error, which we check
+   for and then clear so the remaining tests can continue. */
+   if( have_simd ) {
+      astSetI( map, "UseSIMD", 5 );
+      if( astGetI( map, "UseSIMD" ) != 1 ) {
+         stopit( base + 4, status ); /* LCOV_EXCL_LINE */
+      }
+   } else {
+      astSetI( map, "UseSIMD", 1 );
+      if( astOK ) {
+         stopit( base + 4, status ); /* LCOV_EXCL_LINE */
+      } else {
+         astClearStatus;
+      }
+   }
+
+/* Clearing restores the compiled-in default. */
+   astClear( map, "UseSIMD" );
+   if( astTest( map, "UseSIMD" ) ) {
+      stopit( base + 5, status ); /* LCOV_EXCL_LINE */
+   }
+   if( astGetI( map, "UseSIMD" ) != have_simd ) {
+      stopit( base + 6, status ); /* LCOV_EXCL_LINE */
+   }
+}
+
+/* A simple linear 2-in/2-out forward transformation: out0 = 2*in0,
+   out1 = 3*in1 (no inverse). */
+static void TestPolyMap( int *status ) {
+   double coeff[] = { 2.0, 1, 1, 0,
+                      3.0, 2, 0, 1 };
+   double xin[ 16 ];
+   double yin[ 16 ];
+   double xout[ 16 ];
+   double yout[ 16 ];
+   double tol = 1.0e-10;
+   AstPolyMap *pm;
+   int idx;
+
+   if( !astOK )
+      return;
+
+   pm = astPolyMap( 2, 2, 2, coeff, 0, NULL, " " );
+   check_usesimd( (AstMapping *) pm, 1000, status );
+
+/* Force the scalar path and check the transform is still correct. */
+   astSetI( pm, "UseSIMD", 0 );
+
+   for( idx = 0; idx < 16; idx++ ) {
+      xin[ idx ] = 0.1 * idx - 0.5;
+      yin[ idx ] = 0.2 * idx + 1.0;
+   }
+
+   astTran2( pm, 16, xin, yin, 1, xout, yout );
+
+   for( idx = 0; idx < 16; idx++ ) {
+      if( fabs( xout[ idx ] - 2.0 * xin[ idx ] ) > tol ) {
+         stopit( 1100 + idx, status ); /* LCOV_EXCL_LINE */
+      }
+      if( fabs( yout[ idx ] - 3.0 * yin[ idx ] ) > tol ) {
+         stopit( 1200 + idx, status ); /* LCOV_EXCL_LINE */
+      }
+   }
+}
+
+/* A 2x2 diagonal scaling: out0 = 2*in0, out1 = 0.5*in1. */
+static void TestMatrixMap( int *status ) {
+   double diag[] = { 2.0, 0.5 };
+   double xin[ 16 ];
+   double yin[ 16 ];
+   double xout[ 16 ];
+   double yout[ 16 ];
+   double tol = 1.0e-10;
+   AstMatrixMap *mm;
+   int idx;
+
+   if( !astOK )
+      return;
+
+   mm = astMatrixMap( 2, 2, 1, diag, " " );
+   check_usesimd( (AstMapping *) mm, 2000, status );
+
+   astSetI( mm, "UseSIMD", 0 );
+
+   for( idx = 0; idx < 16; idx++ ) {
+      xin[ idx ] = 0.1 * idx - 0.5;
+      yin[ idx ] = 0.2 * idx + 1.0;
+   }
+
+   astTran2( mm, 16, xin, yin, 1, xout, yout );
+
+   for( idx = 0; idx < 16; idx++ ) {
+      if( fabs( xout[ idx ] - 2.0 * xin[ idx ] ) > tol ) {
+         stopit( 2100 + idx, status ); /* LCOV_EXCL_LINE */
+      }
+      if( fabs( yout[ idx ] - 0.5 * yin[ idx ] ) > tol ) {
+         stopit( 2200 + idx, status ); /* LCOV_EXCL_LINE */
+      }
+   }
+}
+
+/* Forward maps Cartesian (x,y,z) to spherical (longitude, latitude).  Build
+   8 points (>= the SIMD batch threshold) from known angles, force the scalar
+   path, and check the recovered angles. */
+static void TestSphMap( int *status ) {
+   double lon[ 8 ] = { 0.1, 0.7, -0.4, 2.0, -1.5, 0.3, 1.2, -2.6 };
+   double lat[ 8 ] = { 0.2, -0.5, 0.9, -0.1, 0.6, -1.0, 0.4, -0.3 };
+   double in[ 24 ];
+   double out[ 16 ];
+   double tol = 1.0e-9;
+   AstSphMap *sm;
+   int idx;
+
+   if( !astOK )
+      return;
+
+   sm = astSphMap( " " );
+   check_usesimd( (AstMapping *) sm, 3000, status );
+
+   for( idx = 0; idx < 8; idx++ ) {
+      in[ idx ] = cos( lat[ idx ] ) * cos( lon[ idx ] );
+      in[ 8 + idx ] = cos( lat[ idx ] ) * sin( lon[ idx ] );
+      in[ 16 + idx ] = sin( lat[ idx ] );
+   }
+
+   astSetI( sm, "UseSIMD", 0 );
+   astTranN( sm, 8, 3, 8, in, 1, 2, 8, out );
+
+   for( idx = 0; idx < 8; idx++ ) {
+      if( fabs( out[ idx ] - lon[ idx ] ) > tol ) {
+         stopit( 3100 + idx, status ); /* LCOV_EXCL_LINE */
+      }
+      if( fabs( out[ 8 + idx ] - lat[ idx ] ) > tol ) {
+         stopit( 3200 + idx, status ); /* LCOV_EXCL_LINE */
+      }
+   }
+}
+
+int main( void ) {
+   int status_value = 0;
+   int *status = &status_value;
+
+   astWatch( status );
+   astBegin;
+
+   TestPolyMap( status );
+   TestMatrixMap( status );
+   TestSphMap( status );
+
+   astEnd;
+   astFlushMemory( 1 );
+
+   if( *status == 0 ) {
+      printf( " All UseSIMD tests passed\n" );
+   } else {
+      printf( "UseSIMD tests failed\n" ); /* LCOV_EXCL_LINE */
+   }
+   return *status;
+}

--- a/ast_tester/testsimd.c
+++ b/ast_tester/testsimd.c
@@ -72,6 +72,52 @@ static void check_usesimd( AstMapping *map, int base, int *status ) {
    }
 }
 
+/* Compare a transform result against an expected value, treating AST__BAD as
+   a distinct value that must match exactly. */
+static int approx( double got, double want ) {
+   if( got == AST__BAD || want == AST__BAD ) {
+      return got == want;
+   }
+   return fabs( got - want ) <= 1.0e-10;
+}
+
+/* Build a 2-in/2-out MatrixMap from the given form and matrix, transform the
+   "np" supplied points through it both with SIMD enabled (pass 0) and disabled
+   (pass 1), and check the results against the expected outputs (AST__BAD
+   permitted).  This exercises the matching branches in both TransformLoopSIMD
+   and TransformLoopScalar.  Error codes are offset by "base".
+   If compiled without SIMD support both passes are identical/redundant. */
+static void check_tran2( int form, const double *matrix, int np,
+                         const double *xin, const double *yin,
+                         const double *xexp, const double *yexp,
+                         int base, int *status ) {
+   double xout[ 8 ];
+   double yout[ 8 ];
+   AstMatrixMap *mm;
+   int pass;
+   int i;
+
+   if( !astOK )
+      return;
+
+   for( pass = 0; pass < 2; pass++ ) {
+      mm = astMatrixMap( 2, 2, form, matrix, " " );
+      if( pass == 1 ) {
+         astSetI( mm, "UseSIMD", 0 );
+      }
+      astTran2( mm, np, xin, yin, 1, xout, yout );
+      for( i = 0; i < np; i++ ) {
+         if( !approx( xout[ i ], xexp[ i ] ) ) {
+            stopit( base + 10 * pass + i, status ); /* LCOV_EXCL_LINE */
+         }
+         if( !approx( yout[ i ], yexp[ i ] ) ) {
+            stopit( base + 10 * pass + 100 + i, status ); /* LCOV_EXCL_LINE */
+         }
+      }
+      mm = astAnnul( mm );
+   }
+}
+
 /* A simple linear 2-in/2-out forward transformation: out0 = 2*in0,
    out1 = 3*in1 (no inverse). */
 static void TestPolyMap( int *status ) {
@@ -147,6 +193,89 @@ static void TestMatrixMap( int *status ) {
    }
 }
 
+/* Exercise the FULL, DIAGONAL and UNIT MatrixMap forms together with the
+   AST__BAD-handling and non-square branches of the transform loops, on both
+   the SIMD and scalar paths. */
+static void TestMatrixForms( int *status ) {
+
+/* FULL matrix [[2,1],[0,3]]
+   This covers the zero-element skip and the bad-input propagation: a bad x
+   feeds out0 (coefficient 2) but not out1 (coefficient 0), while a bad y feeds
+   both. */
+   double full[] = { 2.0, 1.0, 0.0, 3.0 };
+   double full_x[] = { 1.0, AST__BAD, 1.0, 3.0 };
+   double full_y[] = { 2.0, 2.0, AST__BAD, -1.0 };
+   double full_x_exp[] = { 4.0, AST__BAD, AST__BAD, 5.0 };
+   double full_y_exp[] = { 6.0, 6.0, AST__BAD, -3.0 };
+
+/* FULL matrix whose second output row is entirely zero, covering the
+   all-zero-row branch (output initialised to 0 with no contributing term). */
+   double zrow[] = { 2.0, 1.0, 0.0, 0.0 };
+   double zrow_x[] = { 1.0, 3.0 };
+   double zrow_y[] = { 2.0, -1.0 };
+   double zrow_x_exp[] = { 4.0, 5.0 };
+   double zrow_y_exp[] = { 0.0, 0.0 };
+
+/* FULL matrix containing a bad element, forcing the SIMD path to fall back to
+   the scalar loop, which propagates AST__BAD through the affected output. */
+   double badm[] = { 2.0, 1.0, AST__BAD, 3.0 };
+   double badm_x[] = { 1.0 };
+   double badm_y[] = { 2.0 };
+   double badm_x_exp[] = { 4.0 };
+   double badm_y_exp[] = { AST__BAD };
+
+/* DIAGONAL matrix with a bad diagonal term: y output is all AST__BAD. */
+   double dbad[] = { 2.0, AST__BAD };
+   double dbad_x[] = { 1.0, 3.0 };
+   double dbad_y[] = { 2.0, -1.0 };
+   double dbad_x_exp[] = { 2.0, 6.0 };
+   double dbad_y_exp[] = { AST__BAD, AST__BAD };
+
+/* UNIT matrix: output is a copy of the input. */
+   double unit_x[] = { 1.0, 3.0 };
+   double unit_y[] = { 2.0, -1.0 };
+
+/* Non-square diagonal (2 inputs, 3 outputs): the extra output row is filled
+   with zeros (the nax < ncoord_out branch). */
+   double diag3[] = { 2.0, 3.0 };
+   double in3[] = { 1.0, 3.0, 2.0, -1.0 };  /* 2 coords x 2 points */
+   double out3[ 6 ];  /* 3 coords x 2 points */
+   AstMatrixMap *mm;
+   int pass;
+
+   if( !astOK )
+      return;
+
+   check_tran2( 0, full, 4, full_x, full_y, full_x_exp, full_y_exp, 2300,
+                status );
+   check_tran2( 0, zrow, 2, zrow_x, zrow_y, zrow_x_exp, zrow_y_exp, 2400,
+                status );
+   check_tran2( 0, badm, 1, badm_x, badm_y, badm_x_exp, badm_y_exp, 2500,
+                status );
+   check_tran2( 1, dbad, 2, dbad_x, dbad_y, dbad_x_exp, dbad_y_exp, 2600,
+                status );
+   check_tran2( 2, NULL, 2, unit_x, unit_y, unit_x, unit_y, 2700, status );
+
+/* Non-square case via astTranN, on both the SIMD and scalar paths. */
+   for( pass = 0; pass < 2; pass++ ) {
+      mm = astMatrixMap( 2, 3, 1, diag3, " " );
+      if( pass == 1 ) {
+         astSetI( mm, "UseSIMD", 0 );
+      }
+      astTranN( mm, 2, 2, 2, in3, 1, 3, 2, out3 );
+      if( !approx( out3[ 0 ], 2.0 ) || !approx( out3[ 1 ], 6.0 ) ) {
+         stopit( 2800 + pass, status ); /* LCOV_EXCL_LINE */
+      }
+      if( !approx( out3[ 2 ], 6.0 ) || !approx( out3[ 3 ], -3.0 ) ) {
+         stopit( 2810 + pass, status ); /* LCOV_EXCL_LINE */
+      }
+      if( !approx( out3[ 4 ], 0.0 ) || !approx( out3[ 5 ], 0.0 ) ) {
+         stopit( 2820 + pass, status ); /* LCOV_EXCL_LINE */
+      }
+      mm = astAnnul( mm );
+   }
+}
+
 /* Forward maps Cartesian (x,y,z) to spherical (longitude, latitude).  Build
    8 points (>= the SIMD batch threshold) from known angles, force the scalar
    path, and check the recovered angles. */
@@ -193,6 +322,7 @@ int main( void ) {
 
    TestPolyMap( status );
    TestMatrixMap( status );
+   TestMatrixForms( status );
    TestSphMap( status );
 
    astEnd;

--- a/cmake/run_grid_test.cmake
+++ b/cmake/run_grid_test.cmake
@@ -16,7 +16,6 @@
 # Optional:
 #   REF_FILE  : reference SVG file (omit for smoke-only)
 #   BOX       : graphics bounds "xlo ylo xhi yhi" (omit for auto)
-#   NO_SIMD   : if set, pass --no-simd to testgrid (disable SIMD on SphMaps)
 
 foreach(_req IN ITEMS TESTGRID HEAD_FILE ATTR FATTR OUT_FILE)
     if(NOT DEFINED ${_req})
@@ -25,9 +24,6 @@ foreach(_req IN ITEMS TESTGRID HEAD_FILE ATTR FATTR OUT_FILE)
 endforeach()
 
 set(_cmd "${TESTGRID}")
-if(DEFINED NO_SIMD AND NO_SIMD)
-    list(APPEND _cmd "--no-simd")
-endif()
 list(APPEND _cmd "${HEAD_FILE}" "${ATTR}" "${FATTR}" "${OUT_FILE}")
 if(DEFINED BOX AND NOT BOX STREQUAL "")
     separate_arguments(_box UNIX_COMMAND "${BOX}")

--- a/cmake/run_grid_test.cmake
+++ b/cmake/run_grid_test.cmake
@@ -16,6 +16,7 @@
 # Optional:
 #   REF_FILE  : reference SVG file (omit for smoke-only)
 #   BOX       : graphics bounds "xlo ylo xhi yhi" (omit for auto)
+#   NO_SIMD   : if set, pass --no-simd to testgrid (disable SIMD on SphMaps)
 
 foreach(_req IN ITEMS TESTGRID HEAD_FILE ATTR FATTR OUT_FILE)
     if(NOT DEFINED ${_req})
@@ -23,7 +24,11 @@ foreach(_req IN ITEMS TESTGRID HEAD_FILE ATTR FATTR OUT_FILE)
     endif()
 endforeach()
 
-set(_cmd "${TESTGRID}" "${HEAD_FILE}" "${ATTR}" "${FATTR}" "${OUT_FILE}")
+set(_cmd "${TESTGRID}")
+if(DEFINED NO_SIMD AND NO_SIMD)
+    list(APPEND _cmd "--no-simd")
+endif()
+list(APPEND _cmd "${HEAD_FILE}" "${ATTR}" "${FATTR}" "${OUT_FILE}")
 if(DEFINED BOX AND NOT BOX STREQUAL "")
     separate_arguments(_box UNIX_COMMAND "${BOX}")
     list(APPEND _cmd ${_box})

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,3 +13,6 @@ ignore:
   - "pal"
   - "erfa"
   - "cminpack"
+# perf/bench_simd.c is a standalone benchmark script that is never executed by
+# the test suite, so should be excluded from codecov's report.
+  - "perf"

--- a/configure.ac
+++ b/configure.ac
@@ -182,6 +182,64 @@ fi
 AM_CONDITIONAL(NOYAML, test x$use_yaml = x0)
 AC_SUBST(YAML, $use_yaml)
 
+#  Check for --enable-simd: optional GCC+libmvec vectorization
+#  Probes -fopenmp-simd, -ffast-math, and -march=x86-64-v3
+#  individually.
+AC_ARG_ENABLE([simd],
+    [AS_HELP_STRING([--enable-simd],
+        [enable GCC+libmvec SIMD vectorization in certain compilation units (default: no)])],
+    [enable_simd=$enableval],
+    [enable_simd=no])
+
+AST_SIMD_FLAGS=
+if test "x$enable_simd" = "xyes"; then
+    if test "x$GCC" = "xyes"; then
+        ast_have_simd=yes
+
+        AC_MSG_CHECKING([whether $CC accepts -fopenmp-simd])
+        ast_save_CFLAGS=$CFLAGS
+        CFLAGS="$CFLAGS -fopenmp-simd"
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
+            [ast_have_fopenmp_simd=yes],
+            [ast_have_fopenmp_simd=no; ast_have_simd=no])
+        CFLAGS=$ast_save_CFLAGS
+        AC_MSG_RESULT([$ast_have_fopenmp_simd])
+
+        AC_MSG_CHECKING([whether $CC accepts -ffast-math])
+        ast_save_CFLAGS=$CFLAGS
+        CFLAGS="$CFLAGS -ffast-math"
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
+            [ast_have_ffast_math=yes],
+            [ast_have_ffast_math=no; ast_have_simd=no])
+        CFLAGS=$ast_save_CFLAGS
+        AC_MSG_RESULT([$ast_have_ffast_math])
+
+        AC_MSG_CHECKING([whether $CC accepts -march=x86-64-v3])
+        ast_save_CFLAGS=$CFLAGS
+        CFLAGS="$CFLAGS -march=x86-64-v3"
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
+            [ast_have_march=yes],
+            [ast_have_march=no; ast_have_simd=no])
+        CFLAGS=$ast_save_CFLAGS
+        AC_MSG_RESULT([$ast_have_march])
+
+        if test "x$ast_have_simd" = "xyes"; then
+            AST_SIMD_FLAGS="-fopenmp-simd -ffast-math -fno-associative-math -march=x86-64-v3"
+        fi
+
+        if test -n "$AST_SIMD_FLAGS"; then
+            AC_DEFINE([AST_HAVE_SIMD], [1],
+                [Define to 1 if SIMD vectorization is enabled for certain TUs])
+            AC_MSG_NOTICE([AST_SIMD_FLAGS: "$AST_SIMD_FLAGS"])
+        else
+            AC_MSG_WARN([--enable-simd: no supported flags available; SIMD not active])
+        fi
+    else
+        AC_MSG_WARN([--enable-simd: only supported with GCC (compiler: $CC)])
+    fi
+fi
+AC_SUBST([AST_SIMD_FLAGS])
+
 # See which variadic function API to use
 AC_CHECK_HEADERS(stdarg.h varargs.h, break)
 

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Performance benchmarks
+
+set(PERF_INCLUDES
+    "${CMAKE_CURRENT_SOURCE_DIR}/.."
+    "${CMAKE_CURRENT_SOURCE_DIR}/../src"
+    "${CMAKE_BINARY_DIR}"
+    "${CMAKE_BINARY_DIR}/src"
+)
+
+set(PERF_LIBS
+    ast
+    $<LINK_LIBRARY:WHOLE_ARCHIVE,ast_err>
+    $<LINK_LIBRARY:WHOLE_ARCHIVE,ast_grf_2.0>
+    $<LINK_LIBRARY:WHOLE_ARCHIVE,ast_grf_3.2>
+    $<LINK_LIBRARY:WHOLE_ARCHIVE,ast_grf_5.6>
+    $<LINK_LIBRARY:WHOLE_ARCHIVE,ast_grf3d>
+    m
+)
+
+add_executable(bench_simd bench_simd.c)
+target_include_directories(bench_simd PRIVATE ${PERF_INCLUDES})
+target_link_libraries(bench_simd PRIVATE ${PERF_LIBS})
+target_compile_definitions(bench_simd PRIVATE HAVE_CONFIG_H)
+# Match the warning/sanitizer/coverage flags applied to the rest of the build
+# so the benchmark links correctly against a sanitizer-instrumented libast.
+ast_apply_dev_options(bench_simd)
+

--- a/perf/bench_simd.c
+++ b/perf/bench_simd.c
@@ -1,0 +1,559 @@
+/* Enable POSIX 2008 (clock_gettime) and glibc extensions (drand48). */
+#define _DEFAULT_SOURCE
+
+/*
+ * bench_simd.c
+ *
+ * Benchmark AST transforms at varying N to evaluate SIMD vectorization gains.
+ *
+ * Benchmarks (each run scalar, and SIMD when the library supports it):
+ *   sphmap_fwd: SphMap (x,y,z) -> (lon,lat): atan2/sqrt via libmvec
+ *   sphmap_inv: SphMap (lon,lat) -> (x,y,z): sin/cos via libmvec
+ *   poly5_fwd: degree-5 2-D PolyMap (Roman WCS SIP-like distortion)
+ *   poly1_fwd: degree-1 2-D PolyMap (Roman WCS rotation/scale)
+ *   matdiag2_fwd: 2x2 diagonal MatrixMap (scale)
+ *   matfull2_fwd: 2x2 full MatrixMap (rotation)
+ *
+ * CSV output (transform column uses _simd / _scalar suffix):
+ *   transform,n_points,rep,time_s
+ * where time_s is the amortised time for one transform of n_points points
+ * (each rep times a calibrated batch of repeated calls; see run_sweep).
+ *
+ * Usage:
+ *   bench_simd [-o output.csv] [-r nreps] [--markdown]
+ */
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "ast.h"
+
+/* N sweep: 1 through 4088x4088 (full Roman WFI science area). */
+static const size_t N_SWEEP[] = {
+    1, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 4096, 16384, 65536,
+    262144, 1048576, 4194304, 16711744
+};
+static const size_t N_N_SWEEP = sizeof(N_SWEEP) / sizeof(N_SWEEP[0]);
+
+#define RAND_SEED 42UL
+#define DEFAULT_REPS 5
+#define IMAGE_HALF 2048.0   /* pixel coord half-range for poly/matrix */
+
+/*
+ * At small N a single astTranP call is dominated by call overhead and clock
+ * resolution rather than transform throughput. Each measurement therefore
+ * times a batch of repeated calls, growing the batch until it runs for at
+ * least MIN_BATCH_S, and reports the amortised per-call time. MAX_BATCH_CALLS
+ * bounds the batch so the tiniest N values do not run unboundedly.
+ */
+#define MIN_BATCH_S 0.02
+#define MAX_BATCH_CALLS ( 1 << 22 )
+
+/*
+ * Degree-5 2-D PolyMap (Roman WCS SIP-like distortion, 10 terms).
+ * Row format: { coeff, out_coord (1-based), pow_x, pow_y }.
+ */
+#define POLY5_NCOEFF 10
+static const double POLY5_COEFF_F[POLY5_NCOEFF * 4] = {
+     0.11034133, 1, 1, 0,
+    -3.0e-8,     1, 2, 0,
+     3.4168e-4,  1, 0, 1,
+    -1.0e-8,     1, 0, 2,
+     1.4e-7,     1, 1, 1,
+     3.1436e-4,  2, 1, 0,
+     7.0e-8,     2, 2, 0,
+     0.10828278, 2, 0, 1,
+     2.1e-7,     2, 0, 2,
+    -2.0e-8,     2, 1, 1,
+};
+
+/* Degree-1 2-D PolyMap (Roman WCS linear transform, 4 terms). */
+#define POLY1_NCOEFF 4
+static const double POLY1_COEFF_F[POLY1_NCOEFF * 4] = {
+    -0.5,       1, 1, 0,
+    -0.8660254, 1, 0, 1,
+    -0.8660254, 2, 1, 0,
+     0.5,       2, 0, 1,
+};
+
+/* 2x2 diagonal scale */
+static const double DIAG2X2[2] = { 2.0, 0.5 };
+
+/*
+ * 2x2 full rotation matrix (same linear transform as poly1_fwd, row-major):
+ */
+static const double ROT2X2[4] = {
+    -0.5,       -0.8660254,
+    -0.8660254,  0.5
+};
+
+#define MAX_SUM_ENTRIES 512
+
+typedef struct {
+    char base[64]; /* transform name without _simd/_scalar suffix */
+    size_t N;
+    int is_simd;   /* 0 = scalar, 1 = SIMD */
+    double mpxs;   /* median throughput in Mpx/s */
+} SumEntry;
+
+static SumEntry g_sum[MAX_SUM_ENTRIES];
+static int g_nsum = 0;
+
+/*
+ * Whether the loaded libast supports runtime SIMD. Determined at startup by
+ * detect_simd() rather than a compile-time macro, since UseSIMD is a runtime
+ * tuning knob: the benchmark need not be rebuilt to match the library.
+ */
+static int g_have_simd = 0;
+
+static void record_sum( const char *base, size_t N, int is_simd,
+                        double median_s ) {
+    if( g_nsum >= MAX_SUM_ENTRIES )
+        return;
+    strncpy( g_sum[g_nsum].base, base, sizeof(g_sum[0].base) - 1 );
+    g_sum[g_nsum].base[ sizeof(g_sum[0].base) - 1 ] = '\0';
+    g_sum[g_nsum].N = N;
+    g_sum[g_nsum].is_simd = is_simd;
+    g_sum[g_nsum].mpxs = ( median_s > 0.0 ) ? (double)N / median_s / 1e6 : 0.0;
+    g_nsum++;
+}
+
+static double lookup_mpxs( const char *base, size_t N, int is_simd ) {
+    for( int i = 0; i < g_nsum; i++ ) {
+        if( strcmp( g_sum[i].base, base ) == 0
+            && g_sum[i].N == N
+            && g_sum[i].is_simd == is_simd )
+            return g_sum[i].mpxs;
+    }
+    return -1.0;
+}
+
+/* Return the set of unique base labels in insertion order. */
+static void unique_bases( char bases[][64], int *n ) {
+    *n = 0;
+    for( int i = 0; i < g_nsum; i++ ) {
+        int found = 0;
+        for( int j = 0; j < *n; j++ ) {
+            if( strcmp( bases[j], g_sum[i].base ) == 0 ) {
+                found = 1;
+                break;
+            }
+        }
+        if( !found && *n < MAX_SUM_ENTRIES )
+            strncpy( bases[(*n)++], g_sum[i].base, 63 );
+    }
+}
+
+static double now_s( void ) {
+    struct timespec ts;
+    clock_gettime( CLOCK_MONOTONIC, &ts );
+    return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
+
+/* Run `ncalls` transforms of N points and return the elapsed seconds, or
+   -1.0 if a transform failed. */
+static double time_batch( AstMapping *map, int ncalls, int forward, size_t N,
+                          int nin, const double **ptr_in,
+                          int nout, double **ptr_out ) {
+    double t0 = now_s();
+    for( int k = 0; k < ncalls; k++ ) {
+        astTranP( map, (int)N, nin, ptr_in, forward, nout, ptr_out );
+        if( !astOK )
+            return -1.0;
+    }
+    return now_s() - t0;
+}
+
+/*
+ * Run the N-sweep for one direction.
+ * Records medians in g_sum for the summary table.
+ */
+static int run_sweep( FILE *fout, AstMapping *map,
+                      const char *base_label, int forward,
+                      int nin, const double **ptr_in,
+                      int nout, double **ptr_out,
+                      int nreps, double *rep_times,
+                      int use_simd ) {
+    const char *suffix = use_simd ? "_simd" : "_scalar";
+    char full_label[80];
+    snprintf( full_label, sizeof(full_label), "%s%s", base_label, suffix );
+
+    /* Apply UseSIMD setting (use_simd=1 is only ever requested when the
+       library reports SIMD support, so the astSet always succeeds). */
+    astSet( (AstObject *) map, use_simd ? "UseSIMD=1" : "UseSIMD=0" );
+    if( !astOK ) {
+        fprintf( stderr, "error: astSet(UseSIMD) failed\n" );
+        return 1;
+    }
+
+    fprintf( stderr, "=== %s ===\n", full_label );
+
+    for( size_t ni = 0; ni < N_N_SWEEP; ni++ ) {
+        size_t N = N_SWEEP[ni];
+
+        /* Calibrate the batch size so a batch runs for at least MIN_BATCH_S.
+           This also serves as a warm-up for the rep measurements below. */
+        int ncalls = 1;
+        for( ;; ) {
+            double dt = time_batch( map, ncalls, forward, N,
+                                    nin, ptr_in, nout, ptr_out );
+            if( dt < 0.0 ) {
+                fprintf( stderr, "error: astTranP failed\n" );
+                return 1;
+            }
+            if( dt >= MIN_BATCH_S || ncalls >= MAX_BATCH_CALLS )
+                break;
+            ncalls *= 2;
+        }
+
+        for( int rep = 0; rep < nreps; rep++ ) {
+            double dt = time_batch( map, ncalls, forward, N,
+                                    nin, ptr_in, nout, ptr_out );
+            if( dt < 0.0 ) {
+                fprintf( stderr, "error: astTranP failed\n" );
+                return 1;
+            }
+
+            /* Amortised per-call time (one call transforms N points). */
+            rep_times[rep] = dt / ncalls;
+            fprintf( fout, "%s,%zu,%d,%.9e\n", full_label, N, rep, rep_times[rep] );
+        }
+        fflush( fout );
+
+        /* Sort reps */
+        for( int a = 0; a < nreps - 1; a++ ) {
+            for( int b = a + 1; b < nreps; b++ ) {
+                if( rep_times[b] < rep_times[a] ) {
+                    double tmp = rep_times[a];
+                    rep_times[a] = rep_times[b];
+                    rep_times[b] = tmp;
+                }
+            }
+        }
+        double median = rep_times[ nreps / 2 ];
+
+        record_sum( base_label, N, use_simd, median );
+
+        fprintf( stderr,
+                 "  %-30s  N=%-8zu  x%-8d  median=%10.6f ms  (%6.1f Mpx/s)\n",
+                 full_label, N, ncalls, median * 1e3, (double)N / median / 1e6 );
+    }
+    return 0;
+}
+
+static int run_both( FILE *fout, AstMapping *map,
+                     const char *base_label, int forward,
+                     int nin, const double **ptr_in,
+                     int nout, double **ptr_out,
+                     int nreps, double *rep_times ) {
+    int rc;
+
+    /* Scalar run always. */
+    rc = run_sweep( fout, map, base_label, forward,
+                    nin, ptr_in, nout, ptr_out, nreps, rep_times, 0 );
+    if( rc )
+        return rc;
+
+    /* SIMD run only when the library reports SIMD support. */
+    if( g_have_simd )
+        rc = run_sweep( fout, map, base_label, forward,
+                        nin, ptr_in, nout, ptr_out, nreps, rep_times, 1 );
+    return rc;
+}
+
+static int bench_sphmap( FILE *fout, AstSphMap *sphmap,
+                         const double *x, const double *y, const double *z,
+                         const double *lon, const double *lat,
+                         double *out0, double *out1, double *out2,
+                         int nreps, double *rep_times ) {
+    const double *fwd_in[3] = { x, y, z };
+    double *fwd_out[2] = { out0, out1 };
+    const double *inv_in[2] = { lon, lat };
+    double *inv_out[3] = { out0, out1, out2 };
+    int rc;
+
+    rc = run_both( fout, (AstMapping *)sphmap, "sphmap_fwd", 1,
+                   3, fwd_in, 2, fwd_out, nreps, rep_times );
+    if( rc )
+        return rc;
+
+    return run_both( fout, (AstMapping *)sphmap, "sphmap_inv", 0,
+                     2, inv_in, 3, inv_out, nreps, rep_times );
+}
+
+static int bench_polymap( FILE *fout, const char *base_label,
+                          int ncoeff, const double *coeff_f,
+                          const double *in0, const double *in1,
+                          double *out0, double *out1,
+                          int nreps, double *rep_times ) {
+    AstPolyMap *polymap = astPolyMap( 2, 2, ncoeff, coeff_f, 0, NULL, " " );
+    if( !astOK ) {
+        fprintf( stderr, "error: failed to create PolyMap '%s'\n", base_label );
+        return 1;
+    }
+
+    const double *ptr_in[2] = { in0, in1 };
+    double *ptr_out[2] = { out0, out1 };
+
+    int rc = run_both( fout, (AstMapping *)polymap, base_label, 1,
+                       2, ptr_in, 2, ptr_out, nreps, rep_times );
+    astAnnul( polymap );
+    return rc;
+}
+
+static int bench_matrixmap( FILE *fout,
+                            const double *in0, const double *in1,
+                            double *out0, double *out1,
+                            int nreps, double *rep_times ) {
+    const double *ptr_in[2] = { in0, in1 };
+    double *ptr_out[2] = { out0, out1 };
+    int rc;
+
+    /* Diagonal 2x2. */
+    AstMatrixMap *diag = astMatrixMap( 2, 2, 1, DIAG2X2, " " );
+    if( !astOK ) {
+        fprintf( stderr, "error: failed to create diagonal MatrixMap\n" );
+        return 1;
+    }
+    rc = run_both( fout, (AstMapping *)diag, "matdiag2_fwd", 1,
+                   2, ptr_in, 2, ptr_out, nreps, rep_times );
+    astAnnul( diag );
+    if( rc )
+        return rc;
+
+    /* Full 2x2 rotation. */
+    AstMatrixMap *rot = astMatrixMap( 2, 2, 0, ROT2X2, " " );
+    if( !astOK ) {
+        fprintf( stderr, "error: failed to create rotation MatrixMap\n" );
+        return 1;
+    }
+    rc = run_both( fout, (AstMapping *)rot, "matfull2_fwd", 1,
+                   2, ptr_in, 2, ptr_out, nreps, rep_times );
+    astAnnul( rot );
+    return rc;
+}
+
+/*
+ * Probe whether the loaded libast supports runtime SIMD. The default value of
+ * the UseSIMD attribute is 1 when SIMD is compiled in and 0 otherwise, so
+ * reading it from a fresh mapping reports support without triggering an error.
+ */
+static int detect_simd( void ) {
+    int have = 0;
+    AstMatrixMap *probe = astMatrixMap( 2, 2, 1, DIAG2X2, " " );
+    if( astOK )
+        have = astGetI( (AstObject *) probe, "UseSIMD" );
+    if( probe )
+        probe = astAnnul( probe );
+    return have;
+}
+
+static void print_summary( void ) {
+    char bases[MAX_SUM_ENTRIES][64];
+    int nbases;
+
+    unique_bases( bases, &nbases );
+
+    printf( "\n=== Summary ===\n" );
+    if( g_have_simd ) {
+        printf( "%-22s  %8s  %14s  %12s  %7s\n",
+                "Transform", "N", "Scalar Mpx/s", "SIMD Mpx/s", "Speedup" );
+        printf( "%-22s  %8s  %14s  %12s  %7s\n",
+                "----------------------", "--------", "--------------",
+                "------------", "-------" );
+    } else {
+        printf( "%-22s  %8s  %14s\n",
+                "Transform", "N", "Scalar Mpx/s" );
+        printf( "%-22s  %8s  %14s\n",
+                "----------------------", "--------", "--------------" );
+    }
+
+    for( int b = 0; b < nbases; b++ ) {
+        for( size_t ni = 0; ni < N_N_SWEEP; ni++ ) {
+            size_t N = N_SWEEP[ni];
+            double sc = lookup_mpxs( bases[b], N, 0 );
+            if( sc < 0.0 )
+                continue;
+
+            printf( "%-22s  %8zu  %14.1f", bases[b], N, sc );
+            if( g_have_simd ) {
+                double sm = lookup_mpxs( bases[b], N, 1 );
+                double sp = ( sm > 0.0 && sc > 0.0 ) ? sm / sc : 0.0;
+                printf( "  %12.1f  %6.2fx", sm, sp );
+            }
+            printf( "\n" );
+        }
+    }
+}
+
+static void print_summary_markdown( void ) {
+    char bases[MAX_SUM_ENTRIES][64];
+    int nbases;
+
+    unique_bases( bases, &nbases );
+
+    printf( "\n### SIMD benchmark summary\n\n" );
+    if( g_have_simd )
+        printf( "| Transform | N | Scalar Mpx/s | SIMD Mpx/s | Speedup |\n"
+                "|-----------|--:|-------------:|-----------:|--------:|\n" );
+    else
+        printf( "| Transform | N | Scalar Mpx/s |\n"
+                "|-----------|--:|-------------:|\n" );
+
+    for( int b = 0; b < nbases; b++ ) {
+        for( size_t ni = 0; ni < N_N_SWEEP; ni++ ) {
+            size_t N = N_SWEEP[ni];
+            double sc = lookup_mpxs( bases[b], N, 0 );
+            if( sc < 0.0 )
+                continue;
+
+            printf( "| %s | %zu | %.1f |", bases[b], N, sc );
+            if( g_have_simd ) {
+                double sm = lookup_mpxs( bases[b], N, 1 );
+                double sp = ( sm > 0.0 && sc > 0.0 ) ? sm / sc : 0.0;
+                printf( " %.1f | %.2fx |", sm, sp );
+            }
+            printf( "\n" );
+        }
+    }
+}
+
+int main( int argc, char *argv[] ) {
+    const char *outpath = NULL;
+    int nreps = DEFAULT_REPS;
+    int markdown = 0;
+    FILE *fout = stdout;
+    int status = 0;
+    int rc = 0;
+    size_t max_n = N_SWEEP[N_N_SWEEP - 1];
+    double *x = NULL;
+    double *y = NULL;
+    double *z = NULL;
+    double *lon = NULL;
+    double *lat = NULL;
+    double *out0 = NULL;
+    double *out1 = NULL;
+    double *out2 = NULL;
+    double *rep_times = NULL;
+    AstSphMap *sphmap = NULL;
+
+    for( int i = 1; i < argc; i++ ) {
+        if( strcmp( argv[i], "-o" ) == 0 && i + 1 < argc ) {
+            outpath = argv[++i];
+        } else if( strcmp( argv[i], "-r" ) == 0 && i + 1 < argc ) {
+            nreps = atoi( argv[++i] );
+            if( nreps < 1 )
+                nreps = 1;
+        } else if( strcmp( argv[i], "--markdown" ) == 0 ) {
+            markdown = 1;
+        } else {
+            fprintf( stderr, "Usage: %s [-o output.csv] [-r nreps] [--markdown]\n",
+                     argv[0] );
+            return 1;
+        }
+    }
+
+    if( outpath ) {
+        fout = fopen( outpath, "w" );
+        if( !fout ) {
+            fprintf( stderr, "error: cannot open %s for writing\n", outpath );
+            return 1;
+        }
+    }
+
+    astWatch( &status );
+    astBegin;
+
+    g_have_simd = detect_simd();
+    fprintf( stderr, "SIMD support: %s\n", g_have_simd ? "yes" : "no" );
+
+    sphmap = astSphMap( "UnitRadius=1" );
+    if( !astOK ) {
+        fprintf( stderr, "error: failed to create SphMap (status=%d)\n", status );
+        rc = 1;
+        goto done;
+    }
+
+    x = malloc( max_n * sizeof(double) );
+    y = malloc( max_n * sizeof(double) );
+    z = malloc( max_n * sizeof(double) );
+    lon = malloc( max_n * sizeof(double) );
+    lat = malloc( max_n * sizeof(double) );
+    out0 = malloc( max_n * sizeof(double) );
+    out1 = malloc( max_n * sizeof(double) );
+    out2 = malloc( max_n * sizeof(double) );
+    rep_times = malloc( (size_t)nreps * sizeof(double) );
+
+    if( !x || !y || !z || !lon || !lat || !out0 || !out1 || !out2 || !rep_times ) {
+        fprintf( stderr, "error: out of memory\n" );
+        rc = 1;
+        goto done;
+    }
+
+    /* Random unit-sphere Cartesian points and matching spherical coords. */
+    srand48( (long)RAND_SEED );
+    for( size_t i = 0; i < max_n; i++ ) {
+        double lo = drand48() * 2.0 * M_PI;
+        double la = (drand48() - 0.5) * M_PI;
+        double cp = cos( la );
+        x[i] = cos( lo ) * cp;
+        y[i] = sin( lo ) * cp;
+        z[i] = sin( la );
+        lon[i] = lo;
+        lat[i] = la;
+    }
+
+    fprintf( fout, "transform,n_points,rep,time_s\n" );
+
+    rc = bench_sphmap( fout, sphmap, x, y, z, lon, lat,
+                       out0, out1, out2, nreps, rep_times );
+    if( rc )
+        goto done;
+
+    /* Reinitialise x/y as centred pixel coordinates. */
+    srand48( (long)RAND_SEED );
+    for( size_t i = 0; i < max_n; i++ ) {
+        x[i] = (drand48() - 0.5) * 2.0 * IMAGE_HALF;
+        y[i] = (drand48() - 0.5) * 2.0 * IMAGE_HALF;
+    }
+
+    rc = bench_polymap( fout, "poly5_fwd", POLY5_NCOEFF, POLY5_COEFF_F,
+                        x, y, out0, out1, nreps, rep_times );
+    if( rc )
+        goto done;
+
+    rc = bench_polymap( fout, "poly1_fwd", POLY1_NCOEFF, POLY1_COEFF_F,
+                        x, y, out0, out1, nreps, rep_times );
+    if( rc )
+        goto done;
+
+    rc = bench_matrixmap( fout, x, y, out0, out1, nreps, rep_times );
+
+done:
+    free( rep_times );
+    free( x );
+    free( y );
+    free( z );
+    free( lon );
+    free( lat );
+    free( out0 );
+    free( out1 );
+    free( out2 );
+
+    astEnd;
+
+    if( outpath )
+        fclose( fout );
+
+    if( !rc && !status ) {
+        if( markdown )
+            print_summary_markdown();
+        else
+            print_summary();
+    }
+
+    return (rc || status) ? 1 : 0;
+}

--- a/src/mapping.c
+++ b/src/mapping.c
@@ -572,7 +572,8 @@ static int (* parent_equal)( AstObject *, AstObject *, int * );
    globals->Class_Init = 0; \
    globals->GetAttrib_Buff[ 0 ] = 0; \
    globals->Unsimplified_Mapping = NULL; \
-   globals->Rate_Disabled = 0;
+   globals->Rate_Disabled = 0; \
+   globals->SIMD_Disabled = 0;
 
 
 /* Create the function that initialises global data for this module. */
@@ -584,6 +585,7 @@ astMAKE_INITGLOBALS(Mapping)
 #define getattrib_buff astGLOBAL(Mapping,GetAttrib_Buff)
 #define unsimplified_mapping astGLOBAL(Mapping,Unsimplified_Mapping)
 #define rate_disabled astGLOBAL(Mapping,Rate_Disabled)
+#define simd_disabled astGLOBAL(Mapping,SIMD_Disabled)
 #define ratefun_pset1_cache astGLOBAL(Mapping,RateFun_Pset1_Cache)
 #define ratefun_pset2_cache astGLOBAL(Mapping,RateFun_Pset2_Cache)
 #define ratefun_next_slot astGLOBAL(Mapping,RateFun_Next_Slot)
@@ -607,6 +609,11 @@ static AstMapping *unsimplified_mapping = NULL;
    significant. If astRate is disabled then it always returns a constant
    value of 1.0. */
 static int rate_disabled = 0;
+
+/* A flag which indicates if SIMD-vectorised Mapping transformations should
+   be disabled in the current thread, forcing the use of the scalar code
+   paths instead. */
+static int simd_disabled = 0;
 
 /* static values used in function "RateFun". */
 static AstPointSet *ratefun_pset1_cache[ RATEFUN_MAX_CACHE ];
@@ -1186,6 +1193,93 @@ int astRateState_( int disabled, int *status ) {
    result = rate_disabled;
    rate_disabled = disabled;
    return result;
+}
+
+int astSIMDState_( int disabled, int *status ) {
+/*
+*+
+*  Name:
+*     astSIMDState
+
+*  Purpose:
+*     Control whether SIMD-vectorised Mapping transformations are disabled.
+
+*  Type:
+*     Protected function.
+
+*  Synopsis:
+*     #include "mapping.h"
+*     int astSIMDState( int disabled )
+
+*  Class Membership:
+*     Mapping member function
+
+*  Description:
+*     This function sets a thread-specific flag which, when non-zero, causes
+*     all SIMD-vectorised Mapping transformations to fall back to their
+*     equivalent scalar code paths. This is used by the Plot class to ensure
+*     that coordinate transformations produce bit-stable results while
+*     drawing, since the adaptive curve-subdivision algorithm is sensitive to
+*     the few-ULP differences between the scalar and vectorised maths
+*     libraries.
+*
+*     It should be called with "disabled" non-zero prior to performing an
+*     operation that requires scalar transformations, and then called again
+*     at the end with the value returned by the first call, in order to
+*     re-instate the original state of the flag.
+
+*  Parameters:
+*     disabled
+*        The new value for the SIMD disabled flag.
+
+*  Returned Value:
+*     The original value of the SIMD disabled flag.
+
+*-
+*/
+   astDECLARE_GLOBALS
+   int result;
+   astGET_GLOBALS(NULL);
+
+   result = simd_disabled;
+   simd_disabled = disabled;
+   return result;
+}
+
+int astSIMDDisabled_( int *status ) {
+/*
+*+
+*  Name:
+*     astSIMDDisabled
+
+*  Purpose:
+*     Determine whether SIMD-vectorised Mapping transformations are disabled.
+
+*  Type:
+*     Protected function.
+
+*  Synopsis:
+*     #include "mapping.h"
+*     int astSIMDDisabled( void )
+
+*  Class Membership:
+*     Mapping member function
+
+*  Description:
+*     This function returns the current value of the thread-specific flag
+*     which controls whether SIMD-vectorised Mapping transformations are
+*     disabled (see astSIMDState). It is intended to be called from within
+*     the SIMD code paths of Mapping sub-classes so that they can fall back
+*     to their scalar equivalents when the flag is set.
+
+*  Returned Value:
+*     Non-zero if SIMD transformations are currently disabled in this thread.
+
+*-
+*/
+   astDECLARE_GLOBALS
+   astGET_GLOBALS(NULL);
+   return simd_disabled;
 }
 
 static int Equal( AstObject *this_object, AstObject *that_object, int *status ) {

--- a/src/mapping.h
+++ b/src/mapping.h
@@ -309,6 +309,10 @@
 *        Add astRemoveRegions.
 *     26-FEB-2010 (DSB):
 *        Added method astQuadApprox.
+*     2-JUN-2026 (EMB):
+*        Added methods astSIMDState and astSIMDDisabled for controlling
+*        whether SIMD-vectorised Mapping transformations are disabled in the
+*        current thread.
 *--
 */
 
@@ -576,6 +580,7 @@ typedef struct AstMappingGlobals {
    char GetAttrib_Buff[ AST__MAPPING_GETATTRIB_BUFF_LEN + 1 ];
    AstMapping *Unsimplified_Mapping;
    int Rate_Disabled;
+   int SIMD_Disabled;
    AstPointSet *RateFun_Pset1_Cache[ AST__MAPPING_RATEFUN_MAX_CACHE ];
    AstPointSet *RateFun_Pset2_Cache[ AST__MAPPING_RATEFUN_MAX_CACHE ];
    int RateFun_Next_Slot;
@@ -725,6 +730,8 @@ void astMapSplitId_( AstMapping *, int, const int *, int *, AstMapping **, int *
 
 #if defined(astCLASS)            /* Protected */
 int astRateState_( int, int * );
+int astSIMDState_( int, int * );
+int astSIMDDisabled_( int * );
 AstPointSet *astTransform_( AstMapping *, AstPointSet *, int, AstPointSet *, int * );
 int astGetInvert_( AstMapping *, int * );
 int astGetIsSimple_( AstMapping *, int * );
@@ -961,6 +968,8 @@ astINVOKE(V,astMapSplitId_(astCheckMapping(this),nin,in,out,map,STATUS_PTR))
 
 #if defined(astCLASS)            /* Protected */
 #define astRateState(disabled) astRateState_(disabled,STATUS_PTR)
+#define astSIMDState(disabled) astSIMDState_(disabled,STATUS_PTR)
+#define astSIMDDisabled() astSIMDDisabled_(STATUS_PTR)
 #define astClearInvert(this) \
 astINVOKE(V,astClearInvert_(astCheckMapping(this),STATUS_PTR))
 #define astClearReport(this) \

--- a/src/matrixmap.c
+++ b/src/matrixmap.c
@@ -192,6 +192,18 @@ f     The MatrixMap class does not define any new routines beyond those
 *        astMtrGet now has option to return the expanded matrix.
 *     14-AUG-2020 (DSB):
 *        Added argument "order" to astMtrEuler.
+*     2-JUN-2026 (EMB):
+*        Refactor: factor out TransformLoopScalar and TransformLoopSIMD from
+*        Transform.  Add TransformLoop vtable slot.  Transform becomes a thin
+*        wrapper.  Add UseSIMD string attribute (default 1 when SIMD available,
+*        0 otherwise) accessible via astSet/astGet.  For a full matrix,
+*        TransformLoopSIMD computes each output coordinate with the point loop
+*        innermost under #pragma omp simd (GCC emits VFMADD), and runs the
+*        AST__BAD fixup pass only when a vectorised scan finds a bad input.
+*        For a diagonal matrix it uses a branchless blend.  Inputs are
+*        processed in chunks sized so that (ncoord_in + ncoord_out)*chunk
+*        doubles fit in L2 cache, which keeps the reused inputs cache-resident
+*        at large N.
 *     19-JUN-2026 (TIMJ):
 *        Fix MapSplit: a kept row could reach the element-copy loop with a
 *        BAD value in one of the selected columns (a BAD element does not
@@ -261,12 +273,17 @@ static const char *Form[3] = { "Full", "Diagonal", "Unit" }; /* Text values
 /* Pointers to parent class methods which are extended by this class. */
 static AstPointSet *(* parent_transform)( AstMapping *, AstPointSet *, int, AstPointSet *, int * );
 static int *(* parent_mapsplit)( AstMapping *, int, const int *, AstMapping **, int * );
+static const char *(* parent_getattrib)( AstObject *, const char *, int * );
+static int (* parent_testattrib)( AstObject *, const char *, int * );
+static void (* parent_clearattrib)( AstObject *, const char *, int * );
+static void (* parent_setattrib)( AstObject *, const char *, int * );
 
 
 #ifdef THREAD_SAFE
 /* Define how to initialise thread-specific globals. */
 #define GLOBAL_inits \
-   globals->Class_Init = 0;
+   globals->Class_Init = 0; \
+   globals->GetAttrib_Buff[ 0 ] = 0;
 
 /* Create the function that initialises global data for this module. */
 astMAKE_INITGLOBALS(MatrixMap)
@@ -274,6 +291,7 @@ astMAKE_INITGLOBALS(MatrixMap)
 /* Define macros for accessing each item of thread specific global data. */
 #define class_init astGLOBAL(MatrixMap,Class_Init)
 #define class_vtab astGLOBAL(MatrixMap,Class_Vtab)
+#define getattrib_buff astGLOBAL(MatrixMap,GetAttrib_Buff)
 
 
 #include <pthread.h>
@@ -286,6 +304,7 @@ astMAKE_INITGLOBALS(MatrixMap)
    as static variables. */
 static AstMatrixMapVtab class_vtab;   /* Virtual function table */
 static int class_init = 0;       /* Virtual function table initialised? */
+static char getattrib_buff[ 32 ];
 
 #endif
 
@@ -305,6 +324,16 @@ static AstMatrixMap *MtrMult( AstMatrixMap *, AstMatrixMap *, int * );
 static AstMatrixMap *MtrZoom( AstMatrixMap *, double, int * );
 static AstMatrixMap *MtrRot( AstMatrixMap *, double, const double[], int * );
 static AstPointSet *Transform( AstMapping *, AstPointSet *, int, AstPointSet *, int * );
+static void TransformLoopScalar( AstMapping *, int, int, int, int,
+                                 double **, double **, int * );
+#ifdef AST_HAVE_SIMD
+static void TransformLoopSIMD( AstMapping *, int, int, int, int,
+                               double **, double **, int * );
+#endif
+static const char *GetAttrib( AstObject *, const char *, int * );
+static int TestAttrib( AstObject *, const char *, int * );
+static void ClearAttrib( AstObject *, const char *, int * );
+static void SetAttrib( AstObject *, const char *, int * );
 static AstWinMap *MatWin2( AstMatrixMap *, AstWinMap *, int, int, int, int * );
 static double *InvertMatrix( int, int, int, double *, double *, int * );
 static double *MtrGet( AstMatrixMap *, int, int, int *, int * );
@@ -1410,6 +1439,21 @@ void astInitMatrixMapVtab_(  AstMatrixMapVtab *vtab, const char *name, int *stat
 
    parent_transform = mapping->Transform;
    mapping->Transform = Transform;
+
+#ifdef AST_HAVE_SIMD
+   vtab->TransformLoop = TransformLoopSIMD;
+#else
+   vtab->TransformLoop = TransformLoopScalar;
+#endif
+
+   parent_clearattrib = object->ClearAttrib;
+   object->ClearAttrib = ClearAttrib;
+   parent_getattrib = object->GetAttrib;
+   object->GetAttrib = GetAttrib;
+   parent_setattrib = object->SetAttrib;
+   object->SetAttrib = SetAttrib;
+   parent_testattrib = object->TestAttrib;
+   object->TestAttrib = TestAttrib;
 
    parent_mapsplit = mapping->MapSplit;
    mapping->MapSplit = MapSplit;
@@ -5053,6 +5097,382 @@ static int GetTranInverse( AstMapping *this, int *status ) {
 
 }
 
+#ifdef AST_HAVE_SIMD
+static int MatrixChunkSize( int ncoord_in, int ncoord_out ) {
+/* Return the number of points to process per chunk for the FULL MatrixMap
+   SIMD path.  Sizes the chunk so that the input and output sub-arrays for
+   the chunk--(ncoord_in + ncoord_out) * chunk doubles--fit within half
+   the L2 cache.  Uses astCPUCacheSize to detect the L2 size.
+   Clamped to [64, 65536]. */
+   long bytes_per_point;
+   int chunk;
+   bytes_per_point = (long)( ncoord_in + ncoord_out ) * (long)sizeof(double);
+   chunk = (int)( astCPUCacheSize(2) / 2L / bytes_per_point );
+   if( chunk < 64 ) chunk = 64;
+   if( chunk > 65536 ) chunk = 65536;
+   return chunk;
+}
+#endif /* AST_HAVE_SIMD */
+
+static void TransformLoopScalar( AstMapping *this, int forward, int npoint,
+                                 int ncoord_in, int ncoord_out,
+                                 double **ptr_in, double **ptr_out,
+                                 int *status ) {
+/*
+*  Name:
+*     TransformLoopScalar
+
+*  Purpose:
+*     Scalar (non-SIMD) inner loop for MatrixMap Transform.
+
+*  Description:
+*     Implements FULL, DIAGONAL, and UNIT matrix transforms using scalar
+*     loops.  Called directly (non-SIMD build) or as a fallback from
+*     TransformLoopSIMD when UseSIMD=0 or a bad matrix element is found.
+*/
+
+/* Local Variables: */
+   AstMatrixMap *map;            /* Pointer to MatrixMap */
+   double diag_term;             /* Diagonal element value */
+   double *indata;               /* Input data pointer */
+   double *matrix;               /* Matrix element array */
+   double *matrix_element;       /* Current matrix element pointer */
+   double *outdata;              /* Output data pointer */
+   double sum;                   /* Accumulator */
+   double val;                   /* Single input value */
+   int in_coord;                 /* Input coordinate index */
+   int nax;                      /* Min(ncoord_in, ncoord_out) */
+   int out_coord;                /* Output coordinate index */
+   int point;                    /* Point index */
+
+   if( !astOK )
+      return;
+
+   map = (AstMatrixMap *) this;
+   matrix = forward ? map->f_matrix : map->i_matrix;
+
+   if( map->form == FULL ) {
+      for( point = 0; point < npoint; point++ ) {
+         matrix_element = matrix;
+         for( out_coord = 0; out_coord < ncoord_out; out_coord++ ) {
+            sum = 0.0;
+            for( in_coord = 0; in_coord < ncoord_in; in_coord++ ) {
+               if( ( ptr_in[ in_coord ][ point ] == AST__BAD &&
+                                      (*matrix_element) != 0.0 ) ||
+                   (*matrix_element) == AST__BAD ) {
+                  sum = AST__BAD;
+                  matrix_element += ncoord_in - in_coord;
+                  break;
+               } else {
+                  if( ptr_in[ in_coord ][ point ] != AST__BAD )
+                     sum += ptr_in[ in_coord ][ point ] * (*matrix_element);
+                  matrix_element++;
+               }
+            }
+            ptr_out[ out_coord ][ point ] = sum;
+         }
+      }
+
+   } else {
+      nax = ( ncoord_in < ncoord_out ) ? ncoord_in : ncoord_out;
+
+      if( map->form == UNIT ) {
+         for( out_coord = 0; out_coord < nax; out_coord++ )
+            (void) memcpy( ptr_out[ out_coord ],
+                           (const void *) ptr_in[ out_coord ],
+                           sizeof(double) * (size_t) npoint );
+      } else {
+         for( out_coord = 0; out_coord < nax; out_coord++ ) {
+            diag_term = matrix[ out_coord ];
+            outdata = ptr_out[ out_coord ];
+            indata  = ptr_in[ out_coord ];
+            if( diag_term != AST__BAD ) {
+               for( point = 0; point < npoint; point++ ) {
+                  val = *(indata++);
+                  *(outdata++) = ( val != AST__BAD ) ? diag_term * val : AST__BAD;
+               }
+            } else {
+               for( point = 0; point < npoint; point++ )
+                  *(outdata++) = AST__BAD;
+            }
+         }
+      }
+
+      if( nax < ncoord_out ) {
+         outdata = ptr_out[ nax ];
+         for( point = 0; point < npoint; point++ ) *(outdata++) = 0.0;
+         outdata = ptr_out[ nax ];
+         for( out_coord = nax + 1; out_coord < ncoord_out; out_coord++ )
+            (void) memcpy( ptr_out[ out_coord ], (const void *) outdata,
+                           sizeof(double) * (size_t) npoint );
+      }
+   }
+
+/* Suppress unused-variable warning. */
+   (void) map;
+}
+
+#ifdef AST_HAVE_SIMD
+
+static void TransformLoopSIMD( AstMapping *this, int forward, int npoint,
+                               int ncoord_in, int ncoord_out,
+                               double **ptr_in, double **ptr_out, int *status ) {
+/*
+*  Name:
+*     TransformLoopSIMD
+
+*  Purpose:
+*     SIMD-vectorised inner loop for MatrixMap Transform.
+
+*  Description:
+*     FULL matrix: reorders loops to put points innermost, uses L2-aware
+*     chunking, and emits VFMADD via #pragma omp simd.  Falls back to the
+*     scalar path if any matrix element is AST__BAD or UseSIMD=0.
+*     DIAGONAL matrix: branchless VCMPPD + VBLENDVPD + VMULPD blend.
+*     UNIT matrix: simple memcpy (identical to scalar).
+*/
+
+/* Local Variables: */
+   AstMatrixMap *map;            /* Pointer to MatrixMap */
+   double *matrix;               /* Matrix element array */
+   double *indata;               /* Input data for diagonal path */
+   double *outdata;              /* Output data for diagonal path */
+   double diag_term;             /* Diagonal element */
+   double val;                   /* Single point value (diagonal path) */
+   int chunk_n;                  /* Points in current chunk */
+   int chunk_size;               /* L2-aware chunk size */
+   int chunk_start;              /* First point of current chunk */
+   int has_bad_input;            /* True if any input in chunk is AST__BAD */
+   int has_bad_matrix;           /* True if any matrix element is AST__BAD */
+   int in_coord;                 /* Input coordinate index */
+   int idx;                      /* Loop counter in chunk */
+   int nax;                      /* Min(ncoord_in, ncoord_out) */
+   int ntot;                     /* Total matrix elements */
+   int out_coord;                /* Output coordinate index */
+   int point;                    /* Point index (for fixup pass) */
+   int started;                  /* Output accumulator initialised */
+
+   if( !astOK )
+      return;
+
+   map = (AstMatrixMap *) this;
+
+/* Fall back if UseSIMD disabled. */
+   if( map->use_simd == 0 ) {
+      TransformLoopScalar( this, forward, npoint, ncoord_in, ncoord_out,
+                           ptr_in, ptr_out, status );
+      return;
+   }
+
+   matrix = forward ? map->f_matrix : map->i_matrix;
+
+   if( map->form == FULL ) {
+/* Upfront check for bad matrix elements--fall back to scalar if found. */
+      has_bad_matrix = 0;
+      ntot = ncoord_out * ncoord_in;
+      for( idx = 0; idx < ntot && !has_bad_matrix; idx++ )
+         has_bad_matrix = ( matrix[ idx ] == AST__BAD );
+
+      if( has_bad_matrix ) {
+         TransformLoopScalar( this, forward, npoint, ncoord_in, ncoord_out,
+                              ptr_in, ptr_out, status );
+         return;
+      }
+
+/* Chunked SIMD accumulation. */
+      chunk_size = MatrixChunkSize( ncoord_in, ncoord_out );
+
+      for( chunk_start = 0; chunk_start < npoint; chunk_start += chunk_size ) {
+         chunk_n = npoint - chunk_start;
+         if( chunk_n > chunk_size ) chunk_n = chunk_size;
+
+/* Compute each output coordinate in a single pass over the chunk: the first
+   contributing term initialises the accumulator (avoiding a separate zeroing
+   pass and a read-modify-write), and the rest are fused in. */
+         for( out_coord = 0; out_coord < ncoord_out; out_coord++ ) {
+            double *pout = ptr_out[ out_coord ] + chunk_start;
+            started = 0;
+            for( in_coord = 0; in_coord < ncoord_in; in_coord++ ) {
+               double m = matrix[ out_coord * ncoord_in + in_coord ];
+
+               if( m == 0.0 )
+                  continue;
+
+               double *pin = ptr_in[ in_coord ] + chunk_start;
+               if( !started ) {
+                  #pragma omp simd
+                  for( idx = 0; idx < chunk_n; idx++ )
+                     pout[ idx ] = m * pin[ idx ];
+                  started = 1;
+               } else {
+                  #pragma omp simd
+                  for( idx = 0; idx < chunk_n; idx++ )
+                     pout[ idx ] += m * pin[ idx ];
+               }
+            }
+            if( !started ) {
+               #pragma omp simd
+               for( idx = 0; idx < chunk_n; idx++ )
+                  pout[ idx ] = 0.0;
+            }
+         }
+
+/* Fixup: propagating AST__BAD for bad inputs is only needed if the chunk
+   actually contains a bad input.  Detect that with a vectorised scan (the
+   inputs are still hot in cache from the accumulation above) and run the
+   scalar propagation only when necessary -- typical data has no bad values. */
+         has_bad_input = 0;
+         for( in_coord = 0; in_coord < ncoord_in; in_coord++ ) {
+            double *pin = ptr_in[ in_coord ] + chunk_start;
+            int col_bad = 0;
+            #pragma omp simd reduction(|:col_bad)
+            for( idx = 0; idx < chunk_n; idx++ )
+               col_bad |= ( pin[ idx ] == AST__BAD );
+            has_bad_input |= col_bad;
+         }
+
+         if( has_bad_input ) {
+            for( idx = 0; idx < chunk_n; idx++ ) {
+               point = chunk_start + idx;
+               for( in_coord = 0; in_coord < ncoord_in; in_coord++ ) {
+                  if( ptr_in[ in_coord ][ point ] == AST__BAD ) {
+                     for( out_coord = 0; out_coord < ncoord_out; out_coord++ )
+                        if( matrix[ out_coord * ncoord_in + in_coord ] != 0.0 )
+                           ptr_out[ out_coord ][ point ] = AST__BAD;
+                  }
+               }
+            }
+         }
+      }
+
+   } else {
+      nax = ( ncoord_in < ncoord_out ) ? ncoord_in : ncoord_out;
+
+      if( map->form == UNIT ) {
+         for( out_coord = 0; out_coord < nax; out_coord++ )
+            (void) memcpy( ptr_out[ out_coord ],
+                           (const void *) ptr_in[ out_coord ],
+                           sizeof(double) * (size_t) npoint );
+      } else {
+         for( out_coord = 0; out_coord < nax; out_coord++ ) {
+            diag_term = matrix[ out_coord ];
+            outdata = ptr_out[ out_coord ];
+            indata  = ptr_in[ out_coord ];
+            if( diag_term != AST__BAD ) {
+/* Branchless VCMPPD + VBLENDVPD + VMULPD blend. */
+               #pragma omp simd
+               for( point = 0; point < npoint; point++ ) {
+                  val = indata[ point ];
+                  outdata[ point ] = ( val != AST__BAD ) ? diag_term * val : AST__BAD;
+               }
+            } else {
+               for( point = 0; point < npoint; point++ )
+                  *(outdata++) = AST__BAD;
+            }
+         }
+      }
+
+      if( nax < ncoord_out ) {
+         outdata = ptr_out[ nax ];
+         for( point = 0; point < npoint; point++ ) *(outdata++) = 0.0;
+         outdata = ptr_out[ nax ];
+         for( out_coord = nax + 1; out_coord < ncoord_out; out_coord++ )
+            (void) memcpy( ptr_out[ out_coord ], (const void *) outdata,
+                           sizeof(double) * (size_t) npoint );
+      }
+   }
+
+/* Suppress unused-variable warning. */
+   (void) map;
+}
+
+#endif /* AST_HAVE_SIMD */
+
+static void ClearAttrib( AstObject *this_object, const char *attrib,
+                          int *status ) {
+   AstMatrixMap *this = (AstMatrixMap *) this_object;
+
+   if ( !astOK )
+      return;
+
+   if ( !strcmp( attrib, "usesimd" ) ) {
+      this->use_simd = -1;
+   } else {
+      (*parent_clearattrib)( this_object, attrib, status );
+   }
+}
+
+static const char *GetAttrib( AstObject *this_object, const char *attrib,
+                               int *status ) {
+   astDECLARE_GLOBALS
+   AstMatrixMap *this = (AstMatrixMap *) this_object;
+   const char *result = NULL;
+   int ival;
+
+   if ( !astOK )
+      return result;
+
+   astGET_GLOBALS(this_object);
+
+   if ( !strcmp( attrib, "usesimd" ) ) {
+#ifdef AST_HAVE_SIMD
+      ival = ( this->use_simd == -1 ) ? 1 : this->use_simd;
+#else
+      ival = ( this->use_simd == -1 ) ? 0 : this->use_simd;
+#endif
+      (void) sprintf( getattrib_buff, "%d", ival );
+      result = getattrib_buff;
+   } else {
+      result = (*parent_getattrib)( this_object, attrib, status );
+   }
+   return result;
+}
+
+static void SetAttrib( AstObject *this_object, const char *setting,
+                        int *status ) {
+   AstMatrixMap *this = (AstMatrixMap *) this_object;
+   int ival;
+   int len;
+   int nc;
+
+   if ( !astOK )
+      return;
+
+   len = (int) strlen( setting );
+
+   if ( nc = 0,
+        ( 1 == astSscanf( setting, "usesimd= %d %n", &ival, &nc ) )
+        && ( nc >= len ) ) {
+#ifndef AST_HAVE_SIMD
+      if( ival ) {
+         astError( AST__ATSER, "astSet(%s): SIMD support was not compiled in "
+                   "(rebuild with AST_ENABLE_SIMD=ON).", status,
+                   astGetClass( this ) );
+      } else {
+         this->use_simd = 0;
+      }
+#else
+      this->use_simd = ival ? 1 : 0;
+#endif
+   } else {
+      (*parent_setattrib)( this_object, setting, status );
+   }
+}
+
+static int TestAttrib( AstObject *this_object, const char *attrib,
+                        int *status ) {
+   AstMatrixMap *this = (AstMatrixMap *) this_object;
+
+   if ( !astOK )
+      return 0;
+
+   if ( !strcmp( attrib, "usesimd" ) ) {
+      return ( this->use_simd != -1 );
+   } else {
+      return (*parent_testattrib)( this_object, attrib, status );
+   }
+}
+
 static AstPointSet *Transform( AstMapping *this, AstPointSet *in,
                                int forward, AstPointSet *out, int *status ) {
 /*
@@ -5075,8 +5495,10 @@ static AstPointSet *Transform( AstMapping *this, AstPointSet *in,
 *     method inherited from the Mapping class).
 
 *  Description:
-*     This function takes a MatrixMap and a set of points encapsulated in a
-*     PointSet and transforms the points by multiplying them by the matrix.
+*     Thin wrapper: validates arguments, creates the output PointSet, then
+*     delegates to the TransformLoop vtable slot (TransformLoopSIMD or
+*     TransformLoopScalar depending on compilation flags and the UseSIMD
+*     attribute).
 
 *  Parameters:
 *     this
@@ -5110,179 +5532,37 @@ static AstPointSet *Transform( AstMapping *this, AstPointSet *in,
 */
 
 /* Local Variables: */
+   AstMatrixMap *map;            /* Pointer to MatrixMap */
+   AstMatrixMapVtab *vtab;       /* Class virtual function table */
    AstPointSet *result;          /* Pointer to output PointSet */
-   AstMatrixMap *map;            /* Pointer to MatrixMap to be applied */
-   double diag_term;             /* Current diagonal element value */
-   double *indata;               /* Pointer to next input data value */
-   double *matrix;               /* Pointer to start of matrix element array */
-   double *matrix_element;       /* Pointer to current matrix element value */
-   double *outdata;              /* Pointer to next output data value */
    double **ptr_in;              /* Pointer to input coordinate data */
    double **ptr_out;             /* Pointer to output coordinate data */
-   double sum;                   /* Partial output value */
-   double val;                   /* Data value */
-   int in_coord;                 /* Index of output coordinate */
-   int nax;                      /* Output axes for which input axes exist */
-   int ncoord_in;                /* Number of coordinates per input point */
-   int ncoord_out;               /* Number of coordinates per output point */
+   int ncoord_in;                /* Number of input coordinates */
+   int ncoord_out;               /* Number of output coordinates */
    int npoint;                   /* Number of points */
-   int out_coord;                /* Index of output coordinate */
-   int point;                    /* Loop counter for points */
 
 /* Check the global error status. */
    if ( !astOK ) return NULL;
 
-/* Obtain a pointer to the MatrixMap. */
    map = (AstMatrixMap *) this;
 
-/* Apply the parent mapping using the stored pointer to the Transform member
-   function inherited from the parent Mapping class. This function validates
-   all arguments and generates an output PointSet if necessary, but does not
-   actually transform any coordinate values. */
+/* Validate arguments and create the output PointSet. */
    result = (*parent_transform)( this, in, forward, out, status );
 
-/* We will now extend the parent astTransform method by performing the
-   calculations needed to generate the output coordinate values. */
+/* Correct for the Invert flag. */
+   if ( astGetInvert( map ) )
+      forward = !forward;
 
-/* Determine the numbers of points and coordinates per point from the input
-   and output PointSets and obtain pointers for accessing the input and
-   output coordinate values. */
    ncoord_in = astGetNcoord( in );
    ncoord_out = astGetNcoord( result );
    npoint = astGetNpoint( in );
    ptr_in = astGetPoints( in );
    ptr_out = astGetPoints( result );
 
-/* Determine whether to apply the forward or inverse mapping, according to the
-   direction specified and whether the mapping has been inverted. */
-   if ( astGetInvert( map ) ) forward = !forward;
-
-/* Get a pointer to the array holding the required matrix elements, according
-   to the direction of mapping required. */
-   if ( forward ) {
-      matrix = map->f_matrix;
-   } else {
-      matrix = map->i_matrix;
-   }
-
-/* Perform coordinate arithmetic. */
-/* ------------------------------ */
-   if ( astOK ) {
-
-/* First deal with full MatrixMaps in which all matrix elements are stored. */
-      if( map->form == FULL ){
-
-/* Loop to apply the matrix to each point in turn, checking for
-   (and propagating) bad values in the process. The matrix elements are
-   accessed sequentially in row order. The next matrix element to be
-   used is identified by a pointer which is initialised to point to the
-   first element of the matrix prior to processing each point. */
-         for ( point = 0; point < npoint; point++ ) {
-            matrix_element = matrix;
-
-/* Each output co-ordinate value is created by summing the product of the
-   corresponding input co-ordinates and the elements of one row of the
-   matrix. */
-            for ( out_coord = 0; out_coord < ncoord_out; out_coord++ ) {
-               sum = 0.0;
-
-               for ( in_coord = 0; in_coord < ncoord_in; in_coord++ ) {
-
-/*  Check the current input coordinate value and the current matrix element.
-    If the coordinate value is bad, then the output value will also be
-    bad unless the matrix element is zero. That is, a zero matrix element
-    results in the input coordinate value being ignored, even if it is bad.
-    This prevents bad input values being propagated to output axes which
-    are independant of the bad input axis. A bad matrix element always results
-    in the output value being bad. In either of these cases, break out of the
-    loop, remembering to advance the pointer to the next matrix element so
-    that it points to the start of the next row ready for doing the next
-    output coordinate. */
-                  if ( ( ptr_in[ in_coord ][ point ] == AST__BAD &&
-                                         (*matrix_element) != 0.0 ) ||
-                       (*matrix_element) == AST__BAD ) {
-                     sum = AST__BAD;
-                     matrix_element += ncoord_in - in_coord;
-                     break;
-
-/*  If the input coordinate and the current matrix element are both
-    valid, increment the sum by their product, and step to the next matrix
-    element pointer If we arrive here with a bad input value, then the
-    matrix element must be zero, in which case the running sum is left
-    unchanged. */
-                  } else {
-                     if ( ptr_in[ in_coord ][ point ] != AST__BAD ) {
-                        sum += ptr_in[ in_coord ][ point ] * (*matrix_element);
-                     }
-                     matrix_element++;
-                  }
-               }
-
-/*  Store the output coordinate value. */
-               ptr_out[ out_coord ][ point ] = sum;
-
-            }
-
-         }
-
-/* Now deal with unit and diagonal MatrixMaps. */
-      } else {
-
-/* Find the number of output axes for which input data is available. */
-         if( ncoord_in < ncoord_out ){
-            nax = ncoord_in;
-         } else {
-            nax = ncoord_out;
-         }
-
-/* For unit matrices, copy the input axes to the corresponding output axes. */
-         if( map->form == UNIT ){
-            for( out_coord = 0; out_coord < nax; out_coord++ ) {
-               (void) memcpy( ptr_out[ out_coord ],
-                              (const void *) ptr_in[ out_coord ],
-                              sizeof( double )*(size_t)npoint );
-            }
-
-/* For diagonal matrices, scale each input axis using the appropriate
-   diagonal element from the matrix, and store in the output. */
-         } else {
-            for( out_coord = 0; out_coord < nax; out_coord++ ){
-               diag_term = matrix[ out_coord ];
-               outdata = ptr_out[ out_coord ];
-               indata = ptr_in[ out_coord ];
-
-               if( diag_term != AST__BAD ){
-                  for( point = 0; point < npoint; point++ ){
-                     val = *(indata++);
-                     if( val != AST__BAD ){
-                        *(outdata++) = diag_term*val;
-                     } else {
-                        *(outdata++) = AST__BAD;
-                     }
-                  }
-
-               } else {
-                  for( point = 0; point < npoint; point++ ){
-                     *(outdata++) = AST__BAD;
-                  }
-               }
-            }
-         }
-
-/* If there are any remaining output axes, fill the first one with zeros. */
-         if( nax < ncoord_out ){
-            outdata = ptr_out[ nax ];
-            for( point = 0; point < npoint; point++ ) *(outdata++) = 0.0;
-
-/* Copy this axis to any remaining output axes. */
-            outdata = ptr_out[ nax ];
-            for( out_coord = nax + 1; out_coord < ncoord_out; out_coord++ ) {
-               (void) memcpy( ptr_out[ out_coord ], (const void *) outdata,
-                              sizeof( double )*(size_t)npoint );
-            }
-         }
-      }
-   }
+   vtab = (AstMatrixMapVtab *) astVTAB( this );
+   if( astOK )
+      vtab->TransformLoop( this, forward, npoint, ncoord_in, ncoord_out,
+                           ptr_in, ptr_out, status );
 
 /* Return a pointer to the output PointSet. */
    return result;
@@ -6068,6 +6348,7 @@ AstMatrixMap *astInitMatrixMap_( void *mem, size_t size, int init,
          new->f_matrix = fmat;
          new->i_matrix = imat;
          new->det = det;
+         new->use_simd = -1;
 
 /* Attempt to compress the MatrixMap into DIAGONAL or UNIT form. */
          CompressMatrix( new, status );
@@ -6282,6 +6563,9 @@ AstMatrixMap *astLoadMatrixMap_( void *mem, size_t size,
             }
          }
       }
+
+/* UseSIMD is a runtime tuning attribute; not persisted. Default at load. */
+      new->use_simd = -1;
 
 /* If an error occurred, clean up by deleting the new MatrixMap. */
       if ( !astOK ) new = astDelete( new );

--- a/src/matrixmap.c
+++ b/src/matrixmap.c
@@ -5200,8 +5200,12 @@ static void TransformLoopScalar( AstMapping *this, int forward, int npoint,
 
       if( nax < ncoord_out ) {
          outdata = ptr_out[ nax ];
-         for( point = 0; point < npoint; point++ ) *(outdata++) = 0.0;
+
+         for( point = 0; point < npoint; point++ )
+            *(outdata++) = 0.0;
+
          outdata = ptr_out[ nax ];
+
          for( out_coord = nax + 1; out_coord < ncoord_out; out_coord++ )
             (void) memcpy( ptr_out[ out_coord ], (const void *) outdata,
                            sizeof(double) * (size_t) npoint );
@@ -5375,8 +5379,12 @@ static void TransformLoopSIMD( AstMapping *this, int forward, int npoint,
 
       if( nax < ncoord_out ) {
          outdata = ptr_out[ nax ];
-         for( point = 0; point < npoint; point++ ) *(outdata++) = 0.0;
+
+         for( point = 0; point < npoint; point++ )
+            *(outdata++) = 0.0;
+
          outdata = ptr_out[ nax ];
+
          for( out_coord = nax + 1; out_coord < ncoord_out; out_coord++ )
             (void) memcpy( ptr_out[ out_coord ], (const void *) outdata,
                            sizeof(double) * (size_t) npoint );

--- a/src/matrixmap.c
+++ b/src/matrixmap.c
@@ -5257,8 +5257,9 @@ static void TransformLoopSIMD( AstMapping *this, int forward, int npoint,
 
    map = (AstMatrixMap *) this;
 
-/* Fall back if UseSIMD disabled. */
-   if( map->use_simd == 0 ) {
+/* Fall back if UseSIMD disabled for this Mapping, or if SIMD has been
+   disabled globally for this thread. */
+   if( map->use_simd == 0 || astSIMDDisabled() ) {
       TransformLoopScalar( this, forward, npoint, ncoord_in, ncoord_out,
                            ptr_in, ptr_out, status );
       return;

--- a/src/matrixmap.h
+++ b/src/matrixmap.h
@@ -182,6 +182,7 @@ typedef struct AstMatrixMap {
    double *i_matrix;             /* Pointer to inverse matrix */
    int form;                     /* Matrix storage form */
    double det;                   /* Determinant */
+   int use_simd;                 /* Use SIMD-vectorised transform? (-1=unset/default) */
 } AstMatrixMap;
 
 /* Virtual function table. */
@@ -204,6 +205,9 @@ typedef struct AstMatrixMapVtab {
    int (* MtrEuler)( AstMatrixMap *, int, double[3], int * );
    double *(* MtrGet)( AstMatrixMap *, int, int, int *, int * );
    int (* IsDiagonal)( AstMatrixMap *, int * );
+
+   void (*TransformLoop)( AstMapping *, int, int, int, int,
+                          double **, double **, int * );
 } AstMatrixMapVtab;
 
 #if defined(THREAD_SAFE)
@@ -214,6 +218,7 @@ typedef struct AstMatrixMapVtab {
 typedef struct AstMatrixMapGlobals {
    AstMatrixMapVtab Class_Vtab;
    int Class_Init;
+   char GetAttrib_Buff[ 32 ];
 } AstMatrixMapGlobals;
 
 
@@ -262,6 +267,7 @@ AstMatrixMap *astMtrZoom_( AstMatrixMap *,  double, int * );
 int astMtrEuler_( AstMatrixMap *, int, double[3], int * );
 double *astMtrGet_( AstMatrixMap *, int, int, int *, int * );
 int astIsDiagonal_( AstMatrixMap *, int * );
+
 #endif
 
 /* Function interfaces. */

--- a/src/memory.c
+++ b/src/memory.c
@@ -177,6 +177,9 @@
 *        astAppendStringf.
 *     22-APR-2026 (EMB):
 *        Fix undefined behavior with pointer arithmetic in astChrSplit.
+*     2-JUN-2026 (EMB):
+*        Add astCPUCacheSize: query CPU L1D/L2/L3 cache capacity via CPUID
+*        (x86-64) or sysconf fallback.
 */
 
 /* Configuration results. */
@@ -247,6 +250,11 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <limits.h>
+#include <unistd.h>          /* sysconf */
+
+#ifdef __x86_64__
+#include <cpuid.h>           /* __cpuid_count -- GCC built-in on x86-64 */
+#endif
 
 #ifdef THREAD_SAFE
 #include <pthread.h>
@@ -6080,3 +6088,121 @@ static int CompareTimers2( const void *a, const void *b ){
 }
 
 #endif
+
+long astCPUCacheSize_( int level ) {
+/*
+*++
+*  Name:
+*     astCPUCacheSize
+
+*  Purpose:
+*     Return the size of a CPU cache level in bytes.
+
+*  Type:
+*     Public function.
+
+*  Synopsis:
+*     #include "memory.h"
+*     long astCPUCacheSize( int level )
+
+*  Description:
+*     Returns the total capacity in bytes of the requested CPU cache level
+*     (1 = L1 data, 2 = L2, 3 = L3).  The result is determined once by
+*     querying the hardware and then memoised in a static array; subsequent
+*     calls for the same level are free.
+*
+*     Detection strategy (tried in order):
+*       1. CPUID leaf 4 sub-leaf enumeration on x86-64 (Intel Deterministic
+*          Cache Parameters).
+*       2. sysconf(_SC_LEVEL{n}_CACHE_SIZE)
+*       3. Conservative hard-coded fallbacks: L1=32 KiB, L2=512 KiB, L3=8 MiB.
+
+*  Parameters:
+*     level
+*        Cache level: 1 (L1 data), 2 (L2), or 3 (L3).  Values outside
+*        this range return 0.
+
+*  Returned Value:
+*     astCPUCacheSize()
+*        Cache size in bytes, or 0 if level is out of range.
+
+*  Notes:
+*     - This function never sets the AST error status.
+*     - A benign write-write race is possible in multi-threaded programs
+*       (both threads compute the same value from the same hardware query),
+*       but the result is always deterministic.
+*--
+*/
+
+/* CPUID leaf 4 field extractors (x86-64 only).
+   All geometry fields are encoded as (actual_value - 1), so each macro
+   adds 1. Instruction caches are excluded (type == 2). */
+#ifdef __x86_64__
+#define CPUID4_CACHE_TYPE(eax)    ( (eax) & 0x1f )
+#define CPUID4_CACHE_LEVEL(eax)   ( ((eax) >> 5) & 0x7 )
+#define CPUID4_CACHE_TYPE_NULL    0   /* no more descriptors */
+#define CPUID4_CACHE_TYPE_INSTR   2   /* instruction cache--skip */
+/* EBX[11:0]: line size in bytes, minus 1 */
+#define CPUID4_LINE_SIZE(ebx)     ( (long)((ebx) & 0xfff) + 1L )
+/* EBX[21:12]: physical line partitions, minus 1 */
+#define CPUID4_PARTITIONS(ebx)    ( (long)(((ebx) >> 12) & 0x3ff) + 1L )
+/* EBX[31:22]: ways of associativity, minus 1 */
+#define CPUID4_WAYS(ebx)          ( (long)(((ebx) >> 22) & 0x3ff) + 1L )
+/* ECX: number of sets, minus 1 */
+#define CPUID4_SETS(ecx)          ( (long)(ecx) + 1L )
+#endif
+
+   static long sizes[4] = { 0L, 0L, 0L, 0L }; /* indices 1-3 */
+   static const long defaults[4] = { 0L, 32L*1024L, 512L*1024L, 8L*1024L*1024L };
+   long sz = -1L;
+
+/* Range check. */
+   if( level < 1 || level > 3 ) return 0L;
+
+/* Return memoised value if already detected. */
+   if( sizes[ level ] != 0L )
+      return sizes[ level ];
+
+/* x86-64 CPUID leaf 4 */
+#ifdef __x86_64__
+   unsigned eax, ebx, ecx, edx, idx;
+   for( idx = 0; ; idx++ ) {
+      __cpuid_count( 4, idx, eax, ebx, ecx, edx );
+
+      if( CPUID4_CACHE_TYPE( eax ) == CPUID4_CACHE_TYPE_NULL )
+         break;
+
+      if( (int) CPUID4_CACHE_LEVEL( eax ) != level )
+         continue;
+
+      if( CPUID4_CACHE_TYPE( eax ) == CPUID4_CACHE_TYPE_INSTR )
+         continue;
+
+      sizes[ level ] = CPUID4_WAYS( ebx ) * CPUID4_PARTITIONS( ebx )
+                     * CPUID4_LINE_SIZE( ebx ) * CPUID4_SETS( ecx );
+      return sizes[ level ];
+   }
+#endif
+
+/* sysconf fallback */
+#ifdef _SC_LEVEL1_DCACHE_SIZE
+   if( level == 1 )
+      sz = sysconf( _SC_LEVEL1_DCACHE_SIZE );
+#endif
+#ifdef _SC_LEVEL2_CACHE_SIZE
+   if( level == 2 )
+      sz = sysconf( _SC_LEVEL2_CACHE_SIZE );
+#endif
+#ifdef _SC_LEVEL3_CACHE_SIZE
+   if( level == 3 )
+      sz = sysconf( _SC_LEVEL3_CACHE_SIZE );
+#endif
+   if( sz > 0L ) {
+      sizes[ level ] = sz;
+      return sizes[ level ];
+   }
+
+/* Hard-coded fallbacks */
+   sizes[ level ] = defaults[ level ];
+   return sizes[ level ];
+}

--- a/src/memory.c
+++ b/src/memory.c
@@ -6112,8 +6112,8 @@ long astCPUCacheSize_( int level ) {
 *     calls for the same level are free.
 *
 *     Detection strategy (tried in order):
-*       1. CPUID leaf 4 sub-leaf enumeration on x86-64 (Intel Deterministic
-*          Cache Parameters).
+*       1. CPUID deterministic cache parameters on x86-64 (Intel leaf 4, or
+*          the identically-encoded AMD extended leaf 0x8000001D).
 *       2. sysconf(_SC_LEVEL{n}_CACHE_SIZE)
 *       3. Conservative hard-coded fallbacks: L1=32 KiB, L2=512 KiB, L3=8 MiB.
 
@@ -6134,10 +6134,13 @@ long astCPUCacheSize_( int level ) {
 *--
 */
 
-/* CPUID leaf 4 field extractors (x86-64 only).
+/* CPUID cache-descriptor field extractors (x86-64 only). These apply equally
+   to Intel's leaf 4 and AMD's leaf 0x8000001D, which share the same encoding.
    All geometry fields are encoded as (actual_value - 1), so each macro
    adds 1. Instruction caches are excluded (type == 2). */
 #ifdef __x86_64__
+#define CPUID_CACHE_LEAF_INTEL    0x4U
+#define CPUID_CACHE_LEAF_AMD      0x8000001DU
 #define CPUID4_CACHE_TYPE(eax)    ( (eax) & 0x1f )
 #define CPUID4_CACHE_LEVEL(eax)   ( ((eax) >> 5) & 0x7 )
 #define CPUID4_CACHE_TYPE_NULL    0   /* no more descriptors */
@@ -6150,6 +6153,18 @@ long astCPUCacheSize_( int level ) {
 #define CPUID4_WAYS(ebx)          ( (long)(((ebx) >> 22) & 0x3ff) + 1L )
 /* ECX: number of sets, minus 1 */
 #define CPUID4_SETS(ecx)          ( (long)(ecx) + 1L )
+
+/* Test whether the host CPU supports a given CPUID leaf, storing the boolean
+   result in "result". CPUID called with the base of the leaf's range
+   (leaf & 0xFFFF0000 -- 0 for standard leaves, 0x80000000 for extended ones)
+   returns the highest supported leaf in that range in EAX, so the leaf is
+   available when it does not exceed that maximum. */
+#define CPUID_LEAF_SUPPORTED(leaf, result)                               \
+   do {                                                                  \
+      unsigned _eax, _ebx, _ecx, _edx;                                   \
+      __cpuid( (unsigned)(leaf) & 0xFFFF0000U, _eax, _ebx, _ecx, _edx ); \
+      (result) = ( _eax >= (unsigned)(leaf) );                           \
+   } while( 0 )
 #endif
 
    static long sizes[4] = { 0L, 0L, 0L, 0L }; /* indices 1-3 */
@@ -6163,11 +6178,20 @@ long astCPUCacheSize_( int level ) {
    if( sizes[ level ] != 0L )
       return sizes[ level ];
 
-/* x86-64 CPUID leaf 4 */
+/* x86-64 CPUID deterministic cache parameters. */
 #ifdef __x86_64__
    unsigned eax, ebx, ecx, edx, idx;
+   int amd_cache_leaf;
+   unsigned leaf;
+
+/* Intel reports cache geometry in leaf 4, but AMD leaves it empty there and
+   instead uses the identically-encoded extended leaf 0x8000001D. Use that leaf
+   when it is supported (i.e. on AMD); otherwise fall back to leaf 4. */
+   CPUID_LEAF_SUPPORTED( CPUID_CACHE_LEAF_AMD, amd_cache_leaf );
+   leaf = amd_cache_leaf ? CPUID_CACHE_LEAF_AMD : CPUID_CACHE_LEAF_INTEL;
+
    for( idx = 0; ; idx++ ) {
-      __cpuid_count( 4, idx, eax, ebx, ecx, edx );
+      __cpuid_count( leaf, idx, eax, ebx, ecx, edx );
 
       if( CPUID4_CACHE_TYPE( eax ) == CPUID4_CACHE_TYPE_NULL )
          break;
@@ -6183,6 +6207,10 @@ long astCPUCacheSize_( int level ) {
       return sizes[ level ];
    }
 #endif
+
+/* The remaining fall-backs (sysconf, then conservative hard-coded defaults)
+   are only reached when CPUID cache enumeration is unavailable. */
+/* LCOV_EXCL_START */
 
 /* sysconf fallback */
 #ifdef _SC_LEVEL1_DCACHE_SIZE
@@ -6205,4 +6233,5 @@ long astCPUCacheSize_( int level ) {
 /* Hard-coded fallbacks */
    sizes[ level ] = defaults[ level ];
    return sizes[ level ];
+/* LCOV_EXCL_STOP */
 }

--- a/src/memory.h
+++ b/src/memory.h
@@ -246,6 +246,7 @@ char *astChrSub_( const char *, const char *, const char *[], int, int * );
 void astChrTrunc_( char *, int * );
 int astBrackets_( const char *, size_t, size_t, char, char, int, size_t *, size_t *, char **, char **, char **, int * );
 void astFandl_( const char *, size_t, size_t, size_t *, size_t *, int * );
+long astCPUCacheSize_( int level );
 
 #ifdef MEM_PROFILE
 void astStartTimer_( const char *, int, const char *, int * );
@@ -276,6 +277,7 @@ void astEndPM_( int * );
 /* ==================== */
 /* These wrap up the functions defined by this module. */
 
+#define astCPUCacheSize(level) astCPUCacheSize_(level)
 #define astCalloc(nmemb,size) astERROR_INVOKE(astCalloc_(nmemb,size,STATUS_PTR))
 #define astChrMatch(str1,str2) astERROR_INVOKE(astChrMatch_(str1,str2,STATUS_PTR))
 #define astChrMatchN(str1,str2,n) astERROR_INVOKE(astChrMatchN_(str1,str2,n,STATUS_PTR))

--- a/src/plot.c
+++ b/src/plot.c
@@ -18333,6 +18333,7 @@ f        The global status.
    int naxes;              /* No. of axes in the base or current Frame */
    int oldedge0;           /* Default value for Edge(1) */
    int oldedge1;           /* Default value for Edge(2) */
+   int simd_disabled;      /* Original SIMD disabled flag */
    int useint;             /* Do interior labels give us an advantage? */
 
 /* Check the global error status. */
@@ -18357,6 +18358,14 @@ f        The global status.
 /* Ensure AST functions included graphical escape sequences in any
    returned text strings. */
    escs = astEscapes( 1 );
+
+/* Disable SIMD-vectorised Mapping transformations for the duration of the
+   drawing so that coordinate transformations produce bit-stable results.
+   The adaptive curve-subdivision algorithm is sensitive to the few-ULP
+   differences between the scalar and vectorised maths libraries, which can
+   otherwise cause curves to be over-subdivided. Note the original value of
+   the flag so that it can be re-instated at the end. */
+   simd_disabled = astSIMDState( 1 );
 
 /* Note if attributes which have complex dynamic defaults are set
    initially. */
@@ -18618,6 +18627,9 @@ f        The global status.
 /* Restore the original value of the flag which says whether graphical
    escape sequences should be incldued in any returned text strings. */
    astEscapes( escs );
+
+/* Re-instate the original setting of the "SIMD disabled" flag. */
+   astSIMDState( simd_disabled );
 
 /* Copy the total bounding box to the box which is returned by
    astBoundingBox. */

--- a/src/polymap.c
+++ b/src/polymap.c
@@ -6382,8 +6382,9 @@ static void TransformLoopSIMD( AstMapping *this, int forward, int npoint,
 
    map = (AstPolyMap *) this;
 
-/* Fall back if UseSIMD disabled. */
-   if( map->use_simd == 0 ) {
+/* Fall back if UseSIMD disabled for this Mapping, or if SIMD has been
+   disabled globally for this thread. */
+   if( map->use_simd == 0 || astSIMDDisabled() ) {
       TransformLoopScalar( this, forward, npoint, ncoord_in, ncoord_out,
                            ptr_in, ptr_out, status );
       return;

--- a/src/polymap.c
+++ b/src/polymap.c
@@ -151,6 +151,19 @@ f     - AST_POLYTRAN: Fit a PolyMap inverse or forward transformation
 *     28-JUL-2025 (DSB):
 *        - Add protected virtual method astMergeShift.
 *        - Add public static method astShowPoly.
+*     2-JUN-2026 (EMB):
+*        Add optional SIMD-vectorised transform path.  Factor the point loop
+*        out of Transform into TransformLoopScalar and TransformLoopSIMD,
+*        selected via a new TransformLoop vtable slot, leaving Transform as a
+*        thin wrapper.  TransformLoopSIMD inverts the loop order so the
+*        innermost loops over points are independent and GCC emits
+*        VMULPD/VADDPD via #pragma omp simd, followed by a scalar fixup pass
+*        for bad values; inputs are processed in L2-aware chunks (chunk size
+*        from astCPUCacheSize).  Falls back to TransformLoopScalar for small
+*        point counts (where the per-call work-buffer setup dominates) and for
+*        subclasses that override PolyPowers (e.g. ChebyMap).  Add a UseSIMD
+*        attribute (default 1 when SIMD is available, 0 otherwise) for runtime
+*        selection of the scalar path; not serialised to Dump.
 *class--
 */
 
@@ -257,6 +270,12 @@ AstPolyMap *astPolyMapId_( int, int, int, const double[], int, const double[], c
 /* ======================================== */
 static AstMapping *LinearGuess( AstPolyMap *, int * );
 static AstPointSet *Transform( AstMapping *, AstPointSet *, int, AstPointSet *, int * );
+static void TransformLoopScalar( AstMapping *, int, int, int, int,
+                                 double **, double **, int * );
+#ifdef AST_HAVE_SIMD
+static void TransformLoopSIMD( AstMapping *, int, int, int, int,
+                               double **, double **, int * );
+#endif
 static AstPolyMap **GetJacobian( AstPolyMap *, int * );
 static AstPolyMap *MergeShift( AstPolyMap *, AstShiftMap *, int, int, int * );
 static AstPolyMap *PolyTran( AstPolyMap *, int, double, double, int, const double *, const double *, int * );
@@ -465,6 +484,11 @@ static void ClearAttrib( AstObject *this_object, const char *attrib, int *status
 /* ----------- */
    } else if ( !strcmp( attrib, "tolinverse" ) ) {
       astClearTolInverse( this );
+
+/* UseSIMD */
+/* ------- */
+   } else if ( !strcmp( attrib, "usesimd" ) ) {
+      this->use_simd = -1;
 
 /* If the attribute is still not recognised, pass it on to the parent
    method for further interpretation. */
@@ -1912,6 +1936,19 @@ static const char *GetAttrib( AstObject *this_object, const char *attrib, int *s
          result = getattrib_buff;
       }
 
+/* UseSIMD */
+/* ------- */
+   } else if ( !strcmp( attrib, "usesimd" ) ) {
+#ifdef AST_HAVE_SIMD
+      ival = ( this->use_simd == -1 ) ? 1 : this->use_simd;
+#else
+      ival = ( this->use_simd == -1 ) ? 0 : this->use_simd;
+#endif
+      if ( astOK ) {
+         (void) sprintf( getattrib_buff, "%d", ival );
+         result = getattrib_buff;
+      }
+
 /* If the attribute name was not recognised, pass it on to the parent
    method for further interpretation. */
    } else {
@@ -2407,6 +2444,12 @@ void astInitPolyMapVtab_(  AstPolyMapVtab *vtab, const char *name, int *status )
 
    parent_transform = mapping->Transform;
    mapping->Transform = Transform;
+
+#ifdef AST_HAVE_SIMD
+   vtab->TransformLoop = TransformLoopSIMD;
+#else
+   vtab->TransformLoop = TransformLoopScalar;
+#endif
    mapping->GetTranForward = GetTranForward;
    mapping->GetTranInverse = GetTranInverse;
 
@@ -5618,6 +5661,23 @@ static void SetAttrib( AstObject *this_object, const char *setting, int *status 
         && ( nc >= len ) ) {
       astSetTolInverse( this, dval );
 
+/* UseSIMD. */
+/* -------- */
+   } else if ( nc = 0,
+        ( 1 == astSscanf( setting, "usesimd= %d %n", &ival, &nc ) )
+        && ( nc >= len ) ) {
+#ifndef AST_HAVE_SIMD
+      if( ival ) {
+         astError( AST__ATSER, "astSet(%s): SIMD support was not compiled in "
+                   "(rebuild with AST_ENABLE_SIMD=ON).", status,
+                   astGetClass( this ) );
+      } else {
+         this->use_simd = 0;
+      }
+#else
+      this->use_simd = ival ? 1 : 0;
+#endif
+
 /* If the attribute is still not recognised, pass it on to the parent
    method for further interpretation. */
    } else {
@@ -5975,6 +6035,11 @@ static int TestAttrib( AstObject *this_object, const char *attrib, int *status )
    } else if ( !strcmp( attrib, "tolinverse" ) ) {
       result = astTestTolInverse( this );
 
+/* UseSIMD */
+/* ------- */
+   } else if ( !strcmp( attrib, "usesimd" ) ) {
+      result = ( this->use_simd != -1 );
+
 /* If the attribute is still not recognised, pass it on to the parent
    method for further interpretation. */
    } else {
@@ -5983,6 +6048,134 @@ static int TestAttrib( AstObject *this_object, const char *attrib, int *status )
 
 /* Return the result, */
    return result;
+}
+
+static void TransformLoopScalar( AstMapping *this, int forward, int npoint,
+                                 int ncoord_in, int ncoord_out,
+                                 double **ptr_in, double **ptr_out,
+                                 int *status ) {
+/*
+*  Name:
+*     TransformLoopScalar
+
+*  Purpose:
+*     Scalar (non-SIMD) polynomial evaluation inner loop for PolyMap.
+
+*  Description:
+*     Evaluates the polynomial transform at all N points using a scalar
+*     per-point loop.  This is the default path; also used as the fallback
+*     from TransformLoopSIMD when UseSIMD=0 or the PolyPowers vtable slot
+*     has been overridden (e.g. ChebyMap).
+*/
+
+/* Local Variables: */
+   AstPolyMap *map;              /* Pointer to PolyMap */
+   double **coeff;               /* Coefficient value arrays */
+   double **work;                /* Exponentiated axis-value work array */
+   double *outcof;               /* Current coefficient value pointer */
+   double outval;                /* Current output axis value */
+   double term;                  /* Current polynomial term */
+   double xp;                    /* Axis value to required power */
+   int ***power;                 /* Coefficient power arrays */
+   int **outpow;                 /* Powers for current coefficient */
+   int *mxpow;                   /* Max power per input axis */
+   int *ncoeff;                  /* Number of coefficients per output */
+   int in_coord;                 /* Input coordinate index */
+   int ico;                      /* Coefficient index */
+   int nc;                       /* Number of coefficients for current output */
+   int out_coord;                /* Output coordinate index */
+   int point;                    /* Point index */
+   int pow;                      /* Current power */
+
+   if( !astOK )
+      return;
+
+   map = (AstPolyMap *) this;
+
+   if( forward ) {
+      ncoeff = map->ncoeff_f;
+      coeff = map->coeff_f;
+      power = map->power_f;
+      mxpow = map->mxpow_f;
+   } else {
+      ncoeff = map->ncoeff_i;
+      coeff = map->coeff_i;
+      power = map->power_i;
+      mxpow = map->mxpow_i;
+   }
+
+/* Allocate scalar work array [in_coord][pow]. */
+   work = astMalloc( sizeof(double *) * (size_t) ncoord_in );
+   for( in_coord = 0; in_coord < ncoord_in; in_coord++ )
+      work[ in_coord ] = astMalloc(
+         sizeof(double) * (size_t) astMAX( 2, mxpow[ in_coord ] + 1 ) );
+
+   if( astOK ) {
+      for( point = 0; point < npoint; point++ ) {
+
+/* Find the required powers of the input axis values and store them
+   in the work array. Note, using a virtual method here slows the PolyMap
+   Transform function down by about 5%, compared to doing the equivalent
+   calculations in-line. But we need some way to allow the ChebyMap class
+   to over-ride the calculation of the powers, so we must do something
+   like this. If the 5% slow-down is too much, it can be reduced down to
+   about 2% by replacing the invocation of the astPolyPowers_ interface
+   function with a direct call to the implementation function itself.
+   This involves replacing the astPolyPowers call below with this:
+   (**astMEMBER(this,PolyMap,PolyPowers))( (AstPolyMap *) this, work, ncoord_in,
+                                           mxpow, ptr_in, point, forward, status );
+   The above could be wrapped up in an alternative implementation of the
+   astPolyPowers macro, so that it looks the same as the existing code.
+   In fact, this scheme could be more widely used to speed up invocation
+   of virtual functions within AST. The disadvantage is that the interface
+   functions for some virtual methods includes some extra processing,
+   over and above simply invoking the implementation function.
+   Of course the other way to get rid of the 5% slow down, is to
+   revert to using in-line code below, and then replicate this entire
+   function in the ChebyMap class, making suitable changes to use
+   Chebyshev functions in place of simple powers. But that is bad
+   structuring... */
+         astPolyPowers( this, work, ncoord_in, mxpow, ptr_in, point,
+                        forward );
+         for( out_coord = 0; out_coord < ncoord_out; out_coord++ ) {
+            outval = 0.0;
+            outcof = coeff[ out_coord ];
+            outpow = power[ out_coord ];
+            nc = ncoeff[ out_coord ];
+            for( ico = 0; ico < nc && outval != AST__BAD;
+                 ico++, outcof++, outpow++ ) {
+               term = *outcof;
+               if( term == AST__BAD ) {
+                  outval = AST__BAD;
+               } else {
+                  for( in_coord = 0; in_coord < ncoord_in; in_coord++ ) {
+                     pow = (*outpow)[ in_coord ];
+                     if( pow > 0 ) {
+                        xp = work[ in_coord ][ pow ];
+                        if( xp == AST__BAD ) {
+                           outval = AST__BAD;
+                           break;
+                        } else {
+                           term *= xp;
+                        }
+                     }
+                  }
+               }
+               if( outval != AST__BAD )
+                  outval += term;
+            }
+            ptr_out[ out_coord ][ point ] = outval;
+         }
+      }
+   }
+
+   for( in_coord = 0; in_coord < ncoord_in; in_coord++ )
+      work[ in_coord ] = astFree( work[ in_coord ] );
+
+   work = astFree( work );
+
+/* Suppress unused-variable warnings. */
+   (void) map;
 }
 
 static AstPointSet *Transform( AstMapping *this, AstPointSet *in,
@@ -6007,8 +6200,10 @@ static AstPointSet *Transform( AstMapping *this, AstPointSet *in,
 *     method inherited from the Mapping class).
 
 *  Description:
-*     This function takes a PolyMap and a set of points encapsulated in a
-*     PointSet and transforms the points.
+*     Thin wrapper: validates arguments, creates the output PointSet, handles
+*     the IterInverse case, then delegates polynomial evaluation to the
+*     TransformLoop vtable slot (TransformLoopSIMD or TransformLoopScalar
+*     depending on compilation flags and the UseSIMD attribute).
 
 *  Parameters:
 *     this
@@ -6044,188 +6239,322 @@ static AstPointSet *Transform( AstMapping *this, AstPointSet *in,
 /* Local Variables: */
    AstPointSet *result;          /* Pointer to output PointSet */
    AstPolyMap *map;              /* Pointer to PolyMap to be applied */
-   double **coeff;               /* Pointer to coefficient value arrays */
+   AstPolyMapVtab *vtab;         /* Class virtual function table */
    double **ptr_in;              /* Pointer to input coordinate data */
    double **ptr_out;             /* Pointer to output coordinate data */
-   double **work;                /* Pointer to exponentiated axis values */
-   double *outcof;               /* Pointer to next coefficient value */
-   double outval;                /* Output axis value */
-   double term;                  /* Term to be added to output value */
-   double xp;                    /* Exponentiated input axis value */
-   int ***power;                 /* Pointer to coefficient power arrays */
-   int **outpow;                 /* Pointer to next set of axis powers */
-   int *mxpow;                   /* Pointer to max used power for each input */
-   int *ncoeff;                  /* Pointer to no. of coefficients */
-   int in_coord;                 /* Index of output coordinate */
-   int ico;                      /* Coefficient index */
-   int nc;                       /* No. of coefficients in polynomial */
-   int ncoord_in;                /* Number of coordinates per input point */
-   int ncoord_out;               /* Number of coordinates per output point */
+   int ncoord_in;                /* Number of input coordinates */
+   int ncoord_out;               /* Number of output coordinates */
    int npoint;                   /* Number of points */
-   int out_coord;                /* Index of output coordinate */
-   int point;                    /* Loop counter for points */
-   int pow;                      /* Next axis power */
 
 /* Check the global error status. */
    if ( !astOK ) return NULL;
 
-/* Obtain a pointer to the PolyMap. */
    map = (AstPolyMap *) this;
 
-/* Apply the parent mapping using the stored pointer to the Transform member
-   function inherited from the parent Mapping class. This function validates
-   all arguments and generates an output PointSet if necessary, but does not
-   actually transform any coordinate values. */
+/* Validate arguments and create the output PointSet. */
    result = (*parent_transform)( this, in, forward, out, status );
 
-/* Determine whether to apply the original forward or inverse mapping,
-   according to the direction specified and whether the mapping has been
-   inverted. */
+/* Correct for Invert flag. */
    if ( astGetInvert( map ) ) forward = !forward;
 
-/* We will now extend the parent astTransform method by performing the
-   calculations needed to generate the output coordinate values. */
-
-/* If we are using the original inverse transformatiom, and the IterInverse
-   attribute is non-zero, use an iterative inverse algorithm rather than any
-   inverse transformation defined within the PolyMap. */
-   if( !forward && astGetIterInverse(map) ) {
+/* IterInverse path: call the iterative inverse and return early. */
+   if( !forward && astGetIterInverse( map ) ) {
       IterInverse( map, in, result, status );
+      return result;
+   }
 
-/* Otherwise, determine the numbers of points and coordinates per point from
-   the input and output PointSets and obtain pointers for accessing the input
-   and output coordinate values. */
+   ncoord_in = astGetNcoord( in );
+   ncoord_out = astGetNcoord( result );
+   npoint = astGetNpoint( in );
+   ptr_in = astGetPoints( in );
+   ptr_out = astGetPoints( result );
+
+   vtab = (AstPolyMapVtab *) astVTAB( this );
+   if( astOK )
+      vtab->TransformLoop( this, forward, npoint, ncoord_in, ncoord_out,
+                           ptr_in, ptr_out, status );
+
+   return result;
+}
+
+#ifdef AST_HAVE_SIMD
+
+static int SIMDChunkSize( int ncoord_in, int max_mxpow ) {
+/*
+*  Name:
+*     SIMDChunkSize
+
+*  Purpose:
+*     Return the number of points to process per SIMD chunk in TransformLoopSIMD.
+
+*  Description:
+*     Computes a chunk size that keeps the work and term buffers within half
+*     the L2 cache, so the hot data stays cache-resident across passes.
+*     Uses astCPUCacheSize to detect the L2 size.
+
+*  Parameters:
+*     ncoord_in
+*        Number of input coordinates.
+*     max_mxpow
+*        Maximum polynomial power across all input coordinates.
+
+*  Returned Value:
+*     Chunk size in points, clamped to [64, 65536].
+*/
+   long bytes_per_point;
+   int chunk;
+
+/* work[ncoord_in][max_mxpow+1][chunk] doubles + term[chunk] doubles. */
+   bytes_per_point = ( (long)ncoord_in * ( max_mxpow + 1 ) + 1L )
+                     * (long)sizeof(double);
+   chunk = (int)( astCPUCacheSize(2) / 2L / bytes_per_point );
+
+   if( chunk < 64 )
+      chunk = 64;
+
+   if( chunk > 65536 )
+      chunk = 65536;
+
+   return chunk;
+}
+
+/* Minimum point count for which the SIMD path is worthwhile.  Below this the
+   per-call work-buffer allocation (one astMalloc per input coordinate and
+   power) costs more than the vectorisation saves, so we use the scalar loop. */
+#define SIMD_MIN_POINTS 16
+
+static void TransformLoopSIMD( AstMapping *this, int forward, int npoint,
+                               int ncoord_in, int ncoord_out,
+                               double **ptr_in, double **ptr_out, int *status ) {
+/*
+*  Name:
+*     TransformLoopSIMD
+
+*  Purpose:
+*     SIMD-vectorised polynomial evaluation inner loop for PolyMap.
+
+*  Description:
+*     Inverted loop order: outermost loop over coefficients/powers, innermost
+*     loop over points.  The point-loops are independent and GCC vectorises
+*     them with #pragma omp simd (VMULPD for power computation, VADDPD for
+*     accumulation).
+*
+*     Three-pass approach:
+*       Pass 1: work[coord][pow][point] = x[point]^pow for all N points.
+*       Pass 2: for each output, zero then accumulate polynomial terms.
+*       Pass 3: scalar fixup: overwrite with AST__BAD where any input bad.
+*
+*     Falls back to TransformLoopScalar when UseSIMD=0 or PolyPowers is
+*     overridden (e.g. ChebyMap).
+*/
+
+/* Local Variables: */
+   AstPolyMap *map;
+   double ***work;        /* work[in_coord][pow] -> chunk_size doubles */
+   double **coeff;        /* coefficient value arrays */
+   double *outcof;        /* current coefficient value pointer */
+   double *pout;          /* current output coord pointer in chunk */
+   double *term;          /* per-point scratch for term accumulation */
+   double *w0;            /* work[in_coord][0] */
+   double *wprev;         /* work[in_coord][pow-1] */
+   double *wp;            /* current work sub-array */
+   double *xvec;          /* ptr_in[in_coord] + chunk_start */
+   double c;              /* current coefficient value */
+   int ***power;          /* coefficient power arrays */
+   int **outpow;          /* powers for current coefficient */
+   int *mxpow;            /* max powers per input axis */
+   int *ncoeff;           /* number of coefficients per output */
+   int bad;               /* inputs have bad points */
+   int chunk_n;           /* points in current chunk */
+   int chunk_size;        /* chunk size from SIMDChunkSize */
+   int chunk_start;       /* first point in current chunk */
+   int ico;               /* coefficient index */
+   int in_coord;          /* input coordinate index */
+   int max_mxpow;         /* max mxpow across input coords */
+   int nc;                /* number of coefficients per current output */
+   int npow;              /* number of powers per current input */
+   int out_coord;         /* output coordinate index */
+   int point;             /* point index */
+   int pow;               /* current power */
+
+   if( !astOK )
+      return;
+
+   map = (AstPolyMap *) this;
+
+/* Fall back if UseSIMD disabled. */
+   if( map->use_simd == 0 ) {
+      TransformLoopScalar( this, forward, npoint, ncoord_in, ncoord_out,
+                           ptr_in, ptr_out, status );
+      return;
+   }
+
+/* Fall back if a subclass overrides PolyPowers (e.g. ChebyMap). */
+   if( ((AstPolyMapVtab *) astVTAB( this ))->PolyPowers != PolyPowers ) {
+      TransformLoopScalar( this, forward, npoint, ncoord_in, ncoord_out,
+                           ptr_in, ptr_out, status );
+      return;
+   }
+
+/* Fall back for small point counts, where the per-call buffer setup dominates. */
+   if( npoint < SIMD_MIN_POINTS ) {
+      TransformLoopScalar( this, forward, npoint, ncoord_in, ncoord_out,
+                           ptr_in, ptr_out, status );
+      return;
+   }
+
+   if( forward ) {
+      ncoeff = map->ncoeff_f;
+      coeff = map->coeff_f;
+      power = map->power_f;
+      mxpow = map->mxpow_f;
    } else {
-      ncoord_in = astGetNcoord( in );
-      ncoord_out = astGetNcoord( result );
-      npoint = astGetNpoint( in );
-      ptr_in = astGetPoints( in );
-      ptr_out = astGetPoints( result );
+      ncoeff = map->ncoeff_i;
+      coeff = map->coeff_i;
+      power = map->power_i;
+      mxpow = map->mxpow_i;
+   }
 
-/* Get a pointer to the arrays holding the required coefficient
-   values and powers, according to the direction of mapping required. */
-      if ( forward ) {
-         ncoeff = map->ncoeff_f;
-         coeff = map->coeff_f;
-         power = map->power_f;
-         mxpow = map->mxpow_f;
-      } else {
-         ncoeff = map->ncoeff_i;
-         coeff = map->coeff_i;
-         power = map->power_i;
-         mxpow = map->mxpow_i;
-      }
+   max_mxpow = 0;
+   for( in_coord = 0; in_coord < ncoord_in; in_coord++ )
+      if( mxpow[ in_coord ] > max_mxpow ) max_mxpow = mxpow[ in_coord ];
 
-/* Allocate memory to hold the required powers of the input axis values. */
-      work = astMalloc( sizeof( double * )*(size_t) ncoord_in );
+   chunk_size = SIMDChunkSize( ncoord_in, max_mxpow );
+
+   work = astMalloc( sizeof(double **) * (size_t) ncoord_in );
+   term = astMalloc( sizeof(double) * (size_t) chunk_size );
+   if( astOK ) {
       for( in_coord = 0; in_coord < ncoord_in; in_coord++ ) {
-         work[ in_coord ] = astMalloc( sizeof( double )*
-                           (size_t) ( astMAX( 2, mxpow[in_coord]+1 ) ) );
+         npow = astMAX( 2, mxpow[ in_coord ] + 1 );
+         work[ in_coord ] = astMalloc( sizeof(double *) * (size_t) npow );
+         if( astOK ) {
+            for( pow = 0; pow < npow; pow++ )
+               work[ in_coord ][ pow ] = astMalloc(
+                  sizeof(double) * (size_t) chunk_size );
+         }
       }
+   }
 
-/* Perform coordinate arithmetic. */
-/* ------------------------------ */
-      if ( astOK ) {
+/* Process points in chunks of chunk_size so that work + term stay
+   resident in L2 cache across all three passes. */
+   if( astOK ) {
+      for( chunk_start = 0; chunk_start < npoint; chunk_start += chunk_size ) {
+            chunk_n = npoint - chunk_start;
 
-/* Loop to apply the polynomial to each point in turn.*/
-         for ( point = 0; point < npoint; point++ ) {
+            if( chunk_n > chunk_size )
+               chunk_n = chunk_size;
 
-/* Find the required powers of the input axis values and store them
-   in the work array. Note, using a virtual method here slows the PolyMap
-   Transform function down by about 5%, compared to doing the equivalent
-   calculations in-line. But we need some way to allow the ChebyMap class
-   to over-ride the calculation of the powers, so we must do something
-   like this. If the 5% slow-down is too much, it can be reduced down to
-   about 2% by replacing the invocation of the astPolyPowers_ interface
-   function with a direct call to the implementation function itself.
-   This involves replacing the astPolyPowers call below with this:
+/* Compute work[coord][pow][point] = x_coord[point]^pow.
+   Innermost loop over points is independent--GCC vectorises. */
+            for( in_coord = 0; in_coord < ncoord_in; in_coord++ ) {
+               w0 = work[ in_coord ][ 0 ];
+               xvec = ptr_in[ in_coord ] + chunk_start;
 
-   (**astMEMBER(this,PolyMap,PolyPowers))( (AstPolyMap *) this, work, ncoord_in,
-                                           mxpow, ptr_in, point, forward, status );
+               #pragma omp simd
+               for( point = 0; point < chunk_n; point++ )
+                  w0[ point ] = 1.0;
 
-   The above could be wrapped up in an alternative implementation of the
-   astPolyPowers macro, so that it looks the same as the existing code.
-   In fact, this scheme could be more widely used to speed up invocation
-   of virtual functions within AST. The disadvantage is that the interface
-   functions for some virtual methods includes some extra processing,
-   over and above simply invoking the implementation function.
+               for( pow = 1; pow <= mxpow[ in_coord ]; pow++ ) {
+                  wprev = work[ in_coord ][ pow - 1 ];
+                  wp = work[ in_coord ][ pow ];
 
-   Of course the other way to get rid of the 5% slow down, is to
-   revert to using in-line code below, and then replicate this entire
-   function in the ChebyMap class, making suitable changes to use
-   Chebyshev functions in place of simple powers. But that is bad
-   structuring... */
-            astPolyPowers( this, work, ncoord_in, mxpow, ptr_in, point,
-                           forward );
+                  #pragma omp simd
+                  for( point = 0; point < chunk_n; point++ )
+                     wp[ point ] = wprev[ point ] * xvec[ point ];
+               }
+            }
 
-/* Loop round each output. */
+/* For each output coordinate, accumulate all polynomial terms. */
             for( out_coord = 0; out_coord < ncoord_out; out_coord++ ) {
-
-/* Initialise the output value. */
-               outval = 0.0;
-
-/* Get pointers to the coefficients and powers for this output. */
+               pout = ptr_out[ out_coord ] + chunk_start;
+               nc = ncoeff[ out_coord ];
                outcof = coeff[ out_coord ];
                outpow = power[ out_coord ];
 
-/* Loop round all polynomial coefficients.*/
-               nc = ncoeff[ out_coord ];
-               for ( ico = 0; ico < nc && outval != AST__BAD;
-                     ico++, outcof++, outpow++ ) {
+               #pragma omp simd
+               for( point = 0; point < chunk_n; point++ )
+                  pout[ point ] = 0.0;
 
-/* Initialise the current term to be equal to the value of the coefficient.
-   If it is bad, store a bad output value. */
-                  term = *outcof;
-                  if( term == AST__BAD ) {
-                     outval = AST__BAD;
+               for( ico = 0; ico < nc; ico++, outcof++, outpow++ ) {
+                  c = *outcof;
 
-/* Otherwise, loop round all inputs */
-                  } else {
-                     for( in_coord = 0; in_coord < ncoord_in; in_coord++ ) {
+                  if( c == 0.0 )
+                     continue;
 
-/* Get the power of the current input axis value used by the current
-   coefficient. If it is zero, pass on. */
-                        pow = (*outpow)[ in_coord ];
-                        if( pow > 0 ) {
+/* A bad coefficient poisons all outputs for this coordinate (same as
+   the scalar Transform). */
+                  if( c == AST__BAD ) {
+                     #pragma omp simd
+                     for( point = 0; point < chunk_n; point++ )
+                        pout[ point ] = AST__BAD;
 
-/* Get the axis value raised to the appropriate power. */
-                           xp = work[ in_coord ][ pow ];
+                     break;
+                  }
 
-/* If bad, set the output value bad and break. */
-                           if( xp == AST__BAD ) {
-                              outval = AST__BAD;
-                              break;
+/* Initialise per-point term to the coefficient value, then multiply in
+   each input power factor.  Each inner loop over points is independent. */
+                  #pragma omp simd
+                  for( point = 0; point < chunk_n; point++ )
+                     term[ point ] = c;
 
-/* Otherwise multiply the current term by the exponentiated axis value. */
-                           } else {
-                              term *= xp;
-                           }
-                        }
+                  for( in_coord = 0; in_coord < ncoord_in; in_coord++ ) {
+                     pow = (*outpow)[ in_coord ];
+                     if( pow > 0 ) {
+                        wp = work[ in_coord ][ pow ];
+
+                        #pragma omp simd
+                        for( point = 0; point < chunk_n; point++ )
+                           term[ point ] *= wp[ point ];
                      }
                   }
 
-/* Increment the output value by the current term of the polynomial. */
-                  if( outval != AST__BAD ) outval += term;
+                  #pragma omp simd
+                  for( point = 0; point < chunk_n; point++ )
+                     pout[ point ] += term[ point ];
+               }
+            }
 
+/* Fixup -- for each point where any input coord is AST__BAD, overwrite all
+ * outputs with AST__BAD. */
+            for( point = 0; point < chunk_n; point++ ) {
+               bad = 0;
+
+               for( in_coord = 0; in_coord < ncoord_in; in_coord++ ) {
+                  if( ptr_in[ in_coord ][ chunk_start + point ] == AST__BAD ) {
+                     bad = 1;
+                     break;
+                  }
                }
 
-/* Store the output value. */
-               ptr_out[ out_coord ][ point ] = outval;
-
+               if( bad ) {
+                  for( out_coord = 0; out_coord < ncoord_out; out_coord++ )
+                     ptr_out[ out_coord ][ chunk_start + point ] = AST__BAD;
+               }
             }
          }
       }
 
-/* Free resources. */
+/* Free work arrays. */
+   term = astFree( term );
+
+   if( work ) {
       for( in_coord = 0; in_coord < ncoord_in; in_coord++ ) {
-         work[ in_coord ] = astFree( work[ in_coord ] );
+         if( work[ in_coord ] ) {
+            npow = astMAX( 2, mxpow[ in_coord ] + 1 );
+
+            for( pow = 0; pow < npow; pow++ )
+               work[ in_coord ][ pow ] = astFree( work[ in_coord ][ pow ] );
+
+            work[ in_coord ] = astFree( work[ in_coord ] );
+         }
       }
       work = astFree( work );
    }
 
-/* Return a pointer to the output PointSet. */
-   return result;
+/* Suppress unused-variable warning. */
+   (void) map;
 }
+#endif /* AST_HAVE_SIMD */
 
 /* Functions which access class attributes. */
 /* ---------------------------------------- */
@@ -7122,6 +7451,7 @@ AstPolyMap *astInitPolyMap_( void *mem, size_t size, int init,
       new->tolinverse = AST__BAD;
       new->jacobian = NULL;
       new->lintrunc = NULL;
+      new->use_simd = -1;
 
 /* If an error occurred, clean up by deleting the new PolyMap. */
       if ( !astOK ) new = astDelete( new );
@@ -7441,6 +7771,9 @@ AstPolyMap *astLoadPolyMap_( void *mem, size_t size,
 
 /* The linear truncation of the PolyMap has not yet been found. */
       new->lintrunc = NULL;
+
+/* UseSIMD is a runtime tuning attribute; not persisted. Default at load. */
+      new->use_simd = -1;
 
 /* If an error occurred, clean up by deleting the new PolyMap. */
       if ( !astOK ) new = astDelete( new );

--- a/src/polymap.h
+++ b/src/polymap.h
@@ -166,6 +166,7 @@ typedef struct AstPolyMap {
    double tolinverse;         /* Target relative error for iterative inverse */
    struct AstPolyMap **jacobian;/* PolyMaps defining Jacobian of forward transformation */
    AstMapping *lintrunc;      /* A linear truncation of the PolyMap */
+   int use_simd;              /* Use SIMD-vectorised transform? (-1=unset/default) */
 } AstPolyMap;
 
 /* Virtual function table. */
@@ -216,6 +217,9 @@ typedef struct AstPolyMapVtab {
    int (* TestTolInverse)( AstPolyMap *, int * );
    void (* ClearTolInverse)( AstPolyMap *, int * );
    void (* SetTolInverse)( AstPolyMap *, double, int * );
+
+   void (*TransformLoop)( AstMapping *, int, int, int, int,
+                          double **, double **, int * );
 
 } AstPolyMapVtab;
 
@@ -292,6 +296,7 @@ void astShowPoly_( AstPolyMap *, int * );
    int astTestTolInverse_( AstPolyMap *, int * );
    void astClearTolInverse_( AstPolyMap *, int * );
    void astSetTolInverse_( AstPolyMap *, double, int * );
+
 #endif
 
 

--- a/src/sphmap.c
+++ b/src/sphmap.c
@@ -88,6 +88,16 @@ f     The SphMap class does not define any new routines beyond those
 *     8-MAY-20206 (DSB):
 *        Fix bug in MapMerge - UnitMap that replaces back to back SphMaps
 *        was not taking account of the direction of the two SphMaps.
+*     2-JUN-2026 (EMB):
+*        Add optional SIMD-vectorised transform path.  Factor the point loop
+*        out of Transform into TransformLoopScalar and TransformLoopSIMD,
+*        selected via a new TransformLoop vtable slot, leaving Transform as a
+*        thin wrapper.  TransformLoopSIMD uses a two-pass approach: inlined
+*        atan2/sqrt (forward) and sin/cos (inverse) under #pragma omp simd so
+*        GCC routes them through libmvec, followed by a scalar fixup pass for
+*        bad values and poles.  Add a UseSIMD attribute (default 1 when SIMD
+*        is available, 0 otherwise) for runtime selection of the scalar path
+*        for testing or correctness purposes.
 *class--
 */
 
@@ -126,6 +136,7 @@ f     The SphMap class does not define any new routines beyond those
 /* C header files. */
 /* --------------- */
 #include <float.h>
+#include <math.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -196,6 +207,12 @@ static int TestPolarLong( AstSphMap *, int * );
 static void ClearPolarLong( AstSphMap *, int * );
 static void SetPolarLong( AstSphMap *, double, int * );
 
+static void TransformLoopScalar( AstMapping *, int, int, int, int,
+                                 double **, double **, int * );
+#ifdef AST_HAVE_SIMD
+static void TransformLoopSIMD( AstMapping *, int, int, int, int,
+                               double **, double **, int * );
+#endif
 static AstPointSet *Transform( AstMapping *, AstPointSet *, int, AstPointSet *, int * );
 static const char *GetAttrib( AstObject *, const char *, int * );
 static int Equal( AstObject *, AstObject *, int * );
@@ -263,6 +280,11 @@ static void ClearAttrib( AstObject *this_object, const char *attrib, int *status
 /* --------- */
    } else if ( !strcmp( attrib, "polarlong" ) ) {
       astClearPolarLong( this );
+
+/* UseSIMD */
+/* ------- */
+   } else if ( !strcmp( attrib, "usesimd" ) ) {
+      this->use_simd = -1;
 
 /* If the attribute is still not recognised, pass it on to the parent
    method for further interpretation. */
@@ -456,6 +478,19 @@ static const char *GetAttrib( AstObject *this_object, const char *attrib, int *s
          result = getattrib_buff;
       }
 
+/* UseSIMD */
+/* ------- */
+   } else if ( !strcmp( attrib, "usesimd" ) ) {
+#ifdef AST_HAVE_SIMD
+      ival = ( this->use_simd == -1 ) ? 1 : this->use_simd;
+#else
+      ival = ( this->use_simd == -1 ) ? 0 : this->use_simd;
+#endif
+      if ( astOK ) {
+         (void) sprintf( getattrib_buff, "%d", ival );
+         result = getattrib_buff;
+      }
+
 /* If the attribute name was not recognised, pass it on to the parent
    method for further interpretation. */
    } else {
@@ -537,6 +572,12 @@ void astInitSphMapVtab_(  AstSphMapVtab *vtab, const char *name, int *status ) {
    vtab->SetPolarLong = SetPolarLong;
    vtab->GetPolarLong = GetPolarLong;
    vtab->TestPolarLong = TestPolarLong;
+
+#ifdef AST_HAVE_SIMD
+   vtab->TransformLoop = TransformLoopSIMD;
+#else
+   vtab->TransformLoop = TransformLoopScalar;
+#endif
 
 /* Save the inherited pointers to methods that will be extended, and
    replace them with pointers to the new member functions. */
@@ -1034,6 +1075,23 @@ static void SetAttrib( AstObject *this_object, const char *setting, int *status 
         && ( nc >= len ) ) {
       astSetPolarLong( this, dval );
 
+/* UseSIMD */
+/* ------- */
+   } else if ( nc = 0,
+        ( 1 == astSscanf( setting, "usesimd= %d %n", &ival, &nc ) )
+        && ( nc >= len ) ) {
+#ifndef AST_HAVE_SIMD
+      if( ival ) {
+         astError( AST__ATSER, "astSet(%s): SIMD support was not compiled in "
+                   "(rebuild with AST_ENABLE_SIMD=ON).", status,
+                   astGetClass( this ) );
+      } else {
+         this->use_simd = 0;
+      }
+#else
+      this->use_simd = ival ? 1 : 0;
+#endif
+
 /* If the attribute is still not recognised, pass it on to the parent
    method for further interpretation. */
    } else {
@@ -1107,6 +1165,11 @@ static int TestAttrib( AstObject *this_object, const char *attrib, int *status )
    } else if ( !strcmp( attrib, "polarlong" ) ) {
       result = astTestPolarLong( this );
 
+/* UseSIMD */
+/* ------- */
+   } else if ( !strcmp( attrib, "usesimd" ) ) {
+      result = ( this->use_simd != -1 );
+
 /* If the attribute is still not recognised, pass it on to the parent
    method for further interpretation. */
    } else {
@@ -1116,6 +1179,222 @@ static int TestAttrib( AstObject *this_object, const char *attrib, int *status )
 /* Return the result, */
    return result;
 }
+
+static void TransformLoopScalar( AstMapping *this, int forward, int npoint,
+                                 int ncoord_in, int ncoord_out,
+                                 double **ptr_in, double **ptr_out,
+                                 int *status ) {
+/*
+*  Name:
+*     TransformLoopScalar
+
+*  Purpose:
+*     Scalar (non-SIMD) inner loop for SphMap Transform.
+
+*  Description:
+*     Implements the scalar point-by-point evaluation path for forward
+*     (Cartesian->spherical) and inverse (spherical->Cartesian) SphMap
+*     transforms.  Called either directly from Transform (when SIMD is
+*     absent or UseSIMD=0) or as a fallback from TransformLoopSIMD.
+*/
+
+/* Local Variables: */
+   AstSphMap *map;               /* Pointer to SphMap */
+   double *p0;                   /* x / longitude input */
+   double *p1;                   /* y / latitude input */
+   double *p2;                   /* z input (forward only) */
+   double *q0;                   /* longitude / x output */
+   double *q1;                   /* latitude / y output */
+   double *q2;                   /* z output (inverse only) */
+   double mxerr;                 /* Threshold for pole detection */
+   double polarlong;             /* PolarLong attribute value */
+   double v[3];                  /* Single-point work vector */
+   int point;                    /* Per-point loop counter */
+
+   if( !astOK )
+      return;
+
+   map = (AstSphMap *) this;
+
+   if( forward ){
+      polarlong = astGetPolarLong( this );
+      p0 = ptr_in[ 0 ];
+      p1 = ptr_in[ 1 ];
+      p2 = ptr_in[ 2 ];
+      q0 = ptr_out[ 0 ];
+      q1 = ptr_out[ 1 ];
+      for( point = 0; point < npoint; point++ ){
+         if( *p0 != AST__BAD && *p1 != AST__BAD && *p2 != AST__BAD ){
+            v[0] = *p0;
+            v[1] = *p1;
+            v[2] = *p2;
+            mxerr = fabs( 1000.0*v[ 2 ] )*DBL_EPSILON;
+
+            if( fabs( v[ 0 ] ) < mxerr && fabs( v[ 1 ] ) < mxerr ) {
+               if( v[ 2 ] < 0.0 ) {
+                  *(q0++) = polarlong;
+                  *(q1++) = -AST__DPIBY2;
+               } else if( v[ 2 ] > 0.0 ) {
+                  *(q0++) = polarlong;
+                  *(q1++) = AST__DPIBY2;
+               } else {
+                  *(q0++) = AST__BAD;
+                  *(q1++) = AST__BAD;
+               }
+            } else {
+               palDcc2s( v, q0++, q1++ );
+            }
+         } else {
+            *(q0++) = AST__BAD;
+            *(q1++) = AST__BAD;
+         }
+         p0++;
+         p1++;
+         p2++;
+      }
+   } else {
+      q0 = ptr_in[ 0 ];
+      q1 = ptr_in[ 1 ];
+      p0 = ptr_out[ 0 ];
+      p1 = ptr_out[ 1 ];
+      p2 = ptr_out[ 2 ];
+      for( point = 0; point < npoint; point++ ){
+         if( *q0 != AST__BAD && *q1 != AST__BAD ){
+            palDcs2c( *q0, *q1, v );
+            *(p0++) = v[ 0 ];
+            *(p1++) = v[ 1 ];
+            *(p2++) = v[ 2 ];
+         } else {
+            *(p0++) = AST__BAD;
+            *(p1++) = AST__BAD;
+            *(p2++) = AST__BAD;
+         }
+         q0++;
+         q1++;
+      }
+   }
+
+/* Suppress unused parameter warnings. */
+   (void) map;
+   (void) q2;
+   (void) ncoord_in;
+   (void) ncoord_out;
+}
+
+#ifdef AST_HAVE_SIMD
+static void TransformLoopSIMD( AstMapping *this, int forward, int npoint,
+                               int ncoord_in, int ncoord_out,
+                               double **ptr_in, double **ptr_out, int *status ) {
+/*
+*  Name:
+*     TransformLoopSIMD
+
+*  Purpose:
+*     SIMD-vectorised inner loop for SphMap Transform.
+
+*  Description:
+*     Two-pass approach: a #pragma omp simd pass dispatches atan2/sqrt
+*     (forward) or sin/cos (inverse) through libmvec, followed by a scalar
+*     fixup pass for bad values and poles.  Falls back to TransformLoopScalar
+*     for small batches (N < 8) or when UseSIMD is 0.
+*/
+
+/* Local Variables: */
+   double *p0;                   /* x / longitude input */
+   double *p1;                   /* y / latitude input */
+   double *p2;                   /* z input (forward only) */
+   double *q0;                   /* longitude / x output */
+   double *q1;                   /* latitude / y output */
+   double mxerr;                 /* Threshold for pole detection */
+   double polarlong;             /* PolarLong attribute value */
+   int point;                    /* Per-point loop counter */
+
+/* Fall back for small N or when UseSIMD is disabled. */
+   {
+      AstSphMap *map = (AstSphMap *) this;
+      int use_simd = ( map->use_simd == -1 ) ? 1 : map->use_simd;
+      if( npoint < 8 || !use_simd ) {
+         TransformLoopScalar( this, forward, npoint, ncoord_in, ncoord_out,
+                              ptr_in, ptr_out, status );
+         return;
+      }
+   }
+
+   if( forward ){
+      polarlong = astGetPolarLong( this );
+      p0 = ptr_in[ 0 ];
+      p1 = ptr_in[ 1 ];
+      p2 = ptr_in[ 2 ];
+      q0 = ptr_out[ 0 ];
+      q1 = ptr_out[ 1 ];
+
+/* speculative trig on all points via libmvec. */
+      #pragma omp simd
+      for( point = 0; point < npoint; point++ ) {
+         double x = p0[ point ];
+         double y = p1[ point ];
+         double z = p2[ point ];
+         double d2 = x*x + y*y;
+         q0[ point ] = atan2( y, x );
+         q1[ point ] = atan2( z, sqrt( d2 ) );
+      }
+
+/* scalar fixup for bad inputs and poles. */
+      for( point = 0; point < npoint; point++ ) {
+         if( p0[ point ] == AST__BAD || p1[ point ] == AST__BAD ||
+             p2[ point ] == AST__BAD ) {
+            q0[ point ] = AST__BAD;
+            q1[ point ] = AST__BAD;
+         } else {
+            mxerr = fabs( 1000.0*p2[ point ] )*DBL_EPSILON;
+            if( fabs( p0[ point ] ) < mxerr && fabs( p1[ point ] ) < mxerr ) {
+               if( p2[ point ] < 0.0 ) {
+                  q0[ point ] = polarlong;
+                  q1[ point ] = -AST__DPIBY2;
+               } else if( p2[ point ] > 0.0 ) {
+                  q0[ point ] = polarlong;
+                  q1[ point ] = AST__DPIBY2;
+               } else {
+                  q0[ point ] = AST__BAD;
+                  q1[ point ] = AST__BAD;
+               }
+            }
+         }
+      }
+
+   } else {
+      q0 = ptr_in[ 0 ];
+      q1 = ptr_in[ 1 ];
+      p0 = ptr_out[ 0 ];
+      p1 = ptr_out[ 1 ];
+      p2 = ptr_out[ 2 ];
+
+/* speculative sin/cos on all points via libmvec. */
+      #pragma omp simd
+      for( point = 0; point < npoint; point++ ) {
+         double theta = q0[ point ];
+         double phi   = q1[ point ];
+         double cp = cos( phi );
+         p0[ point ] = cos( theta ) * cp;
+         p1[ point ] = sin( theta ) * cp;
+         p2[ point ] = sin( phi );
+      }
+
+/* overwrite bad-input outputs. */
+      for( point = 0; point < npoint; point++ ) {
+         if( q0[ point ] == AST__BAD || q1[ point ] == AST__BAD ) {
+            p0[ point ] = AST__BAD;
+            p1[ point ] = AST__BAD;
+            p2[ point ] = AST__BAD;
+         }
+      }
+   }
+
+/* Suppress unused parameter warnings. */
+   (void) ncoord_in;
+   (void) ncoord_out;
+}
+#endif /* AST_HAVE_SIMD */
 
 static AstPointSet *Transform( AstMapping *this, AstPointSet *in,
                                int forward, AstPointSet *out, int *status ) {
@@ -1132,16 +1411,17 @@ static AstPointSet *Transform( AstMapping *this, AstPointSet *in,
 *  Synopsis:
 *     #include "sphmap.h"
 *     AstPointSet *Transform( AstMapping *this, AstPointSet *in,
-*                             int forward, AstPointSet *out, int *status, int *status )
+*                             int forward, AstPointSet *out, int *status )
 
 *  Class Membership:
 *     SphMap member function (over-rides the astTransform protected
 *     method inherited from the Mapping class).
 
 *  Description:
-*     This function takes a SphMap and a set of points encapsulated in a
-*     PointSet and transforms the points from Cartesian coordinates to
-*     spherical coordinates.
+*     Thin wrapper: validates arguments, creates the output PointSet, then
+*     delegates to the TransformLoop vtable slot (TransformLoopSIMD or
+*     TransformLoopScalar depending on compilation flags and the UseSIMD
+*     attribute).
 
 *  Parameters:
 *     this
@@ -1156,8 +1436,6 @@ static AstPointSet *Transform( AstMapping *this, AstPointSet *in,
 *        Pointer to a PointSet which will hold the transformed (output)
 *        coordinate values. A NULL value may also be given, in which case a
 *        new PointSet will be created by this function.
-*     status
-*        Pointer to the inherited status variable.
 *     status
 *        Pointer to the inherited status variable.
 
@@ -1176,133 +1454,34 @@ static AstPointSet *Transform( AstMapping *this, AstPointSet *in,
 
 /* Local Variables: */
    AstPointSet *result;          /* Pointer to output PointSet */
-   AstSphMap *map;               /* Pointer to SphMap to be applied */
+   AstSphMapVtab *vtab;          /* Pointer to class vtable */
    double **ptr_in;              /* Pointer to input coordinate data */
    double **ptr_out;             /* Pointer to output coordinate data */
+   int ncoord_in;                /* Number of input coordinates */
+   int ncoord_out;               /* Number of output coordinates */
    int npoint;                   /* Number of points */
-   int point;                    /* Loop counter for points */
-   double *p0;                   /* Pointer to x axis value */
-   double *p1;                   /* Pointer to y axis value */
-   double *p2;                   /* Pointer to z axis value */
-   double *q0;                   /* Pointer to longitude value */
-   double *q1;                   /* Pointer to latitude value */
-   double mxerr;                 /* Largest value which is effectively zero */
-   double polarlong;             /* Longitude at either pole */
-   double v[3];                  /* Vector for a single point */
 
 /* Check the global error status. */
-   if ( !astOK ) return NULL;
+   if ( !astOK )
+      return NULL;
 
-/* Obtain a pointer to the SphMap. */
-   map = (AstSphMap *) this;
-
-/* Apply the parent mapping using the stored pointer to the Transform member
-   function inherited from the parent Mapping class. This function validates
-   all arguments and generates an output PointSet if necessary, but does not
-   actually transform any coordinate values. */
+/* Validate arguments and create the output PointSet. */
    result = (*parent_transform)( this, in, forward, out, status );
 
-/* We will now extend the parent astTransform method by performing the
-   calculations needed to generate the output coordinate values. */
+/* Correct for the Invert flag. */
+   if ( astGetInvert( this ) ) forward = !forward;
 
-/* Determine the numbers of points and coordinates per point from the input
-   PointSet and obtain pointers for accessing the input and output coordinate
-   values. */
    npoint = astGetNpoint( in );
+   ncoord_in = astGetNcoord( in );
+   ncoord_out = astGetNcoord( result );
    ptr_in = astGetPoints( in );
    ptr_out = astGetPoints( result );
 
-/* Determine whether to apply the forward or inverse mapping, according to the
-   direction specified and whether the mapping has been inverted. */
-   if ( astGetInvert( map ) ) forward = !forward;
+   vtab = (AstSphMapVtab *) astVTAB( this );
 
-/* Perform coordinate arithmetic. */
-/* ------------------------------ */
-   if( astOK ){
-
-/* First deal with forward mappings from Cartesian to Spherical. */
-      if( forward ){
-
-/* Get the longitude to return at either pole. */
-         polarlong = astGetPolarLong( this );
-
-/* Store pointers to the input Cartesian axes. */
-         p0 = ptr_in[ 0 ];
-         p1 = ptr_in[ 1 ];
-         p2 = ptr_in[ 2 ];
-
-/* Store pointers to the output Spherical axes. */
-         q0 = ptr_out[ 0 ];
-         q1 = ptr_out[ 1 ];
-
-/* Apply the mapping to every point. */
-         for( point = 0; point < npoint; point++ ){
-            if( *p0 != AST__BAD && *p1 != AST__BAD && *p2 != AST__BAD ){
-               v[0] = *p0;
-               v[1] = *p1;
-               v[2] = *p2;
-
-/* At either pole, return the longitude equal to PolarLong attribute. */
-               mxerr = fabs( 1000.0*v[ 2 ] )*DBL_EPSILON;
-               if( fabs( v[ 0 ] ) < mxerr && fabs( v[ 1 ] ) < mxerr ) {
-                  if( v[ 2 ] < 0.0 ) {
-                     *(q0++) = polarlong;
-                     *(q1++) = -AST__DPIBY2;
-                  } else if( v[ 2 ] > 0.0 ) {
-                     *(q0++) = polarlong;
-                     *(q1++) = AST__DPIBY2;
-                  } else {
-                     *(q0++) = AST__BAD;
-                     *(q1++) = AST__BAD;
-                  }
-
-/* Otherwise use a SLALIB function to do the conversion (SLALIB always
-   returns zero at either pole which is why we make the above check). */
-               } else {
-                  palDcc2s( v, q0++, q1++ );
-               }
-
-            } else {
-               *(q0++) = AST__BAD;
-               *(q1++) = AST__BAD;
-            }
-            p0++;
-            p1++;
-            p2++;
-         }
-
-/* Now deal with inverse mappings from Spherical to Cartesian. */
-      } else {
-
-/* Store pointers to the input Spherical axes. */
-         q0 = ptr_in[ 0 ];
-         q1 = ptr_in[ 1 ];
-
-/* Store pointers to the output Cartesian axes. */
-         p0 = ptr_out[ 0 ];
-         p1 = ptr_out[ 1 ];
-         p2 = ptr_out[ 2 ];
-
-/* Apply the mapping to every point. */
-         for( point = 0; point < npoint; point++ ){
-            if( *q0 != AST__BAD && *q1 != AST__BAD ){
-               palDcs2c( *q0, *q1, v );
-               *(p0++) = v[ 0 ];
-               *(p1++) = v[ 1 ];
-               *(p2++) = v[ 2 ];
-            } else {
-               *(p0++) = AST__BAD;
-               *(p1++) = AST__BAD;
-               *(p2++) = AST__BAD;
-
-            }
-            q0++;
-            q1++;
-         }
-
-      }
-
-   }
+   if( astOK )
+      vtab->TransformLoop( this, forward, npoint, ncoord_in, ncoord_out,
+                           ptr_in, ptr_out, status );
 
 /* Return a pointer to the output PointSet. */
    return result;
@@ -1431,6 +1610,37 @@ astMAKE_CLEAR1(SphMap,PolarLong,polarlong,AST__BAD)
 astMAKE_GET(SphMap,PolarLong,double,0.0,(this->polarlong == AST__BAD ? 0.0 : this->polarlong))
 astMAKE_SET1(SphMap,PolarLong,double,polarlong,value)
 astMAKE_TEST(SphMap,PolarLong,( this->polarlong != AST__BAD ))
+
+/* UseSIMD */
+/* -------- */
+/*
+*att++
+*  Name:
+*     UseSIMD
+
+*  Purpose:
+*     Use SIMD-vectorised transform loop.
+
+*  Type:
+*     Public attribute.
+
+*  Synopsis:
+*     Integer (boolean).
+
+*  Description:
+*     This boolean attribute controls whether the SphMap uses a SIMD-
+*     vectorised transform loop (when compiled with AST_ENABLE_SIMD=ON) or
+*     the scalar fallback.  The default is 1 (enabled) when the library was
+*     built with SIMD support and 0 otherwise.  Setting it to 0 forces the
+*     scalar path, which is useful for correctness testing or to avoid the
+*     1-ULP rounding differences introduced by libmvec vector-math functions.
+*     Setting it to 1 when SIMD support is not compiled in is an error.
+
+*  Applicability:
+*     SphMap
+*        All SphMaps have this attribute.
+*att--
+*/
 
 /* Copy constructor. */
 /* ----------------- */
@@ -1895,6 +2105,7 @@ AstSphMap *astInitSphMap_( void *mem, size_t size, int init,
    input vectors are not all of unit length) to be used. */
       new->unitradius = -1;
       new->polarlong = AST__BAD;
+      new->use_simd = -1;
 
    }
 
@@ -2040,6 +2251,7 @@ AstSphMap *astLoadSphMap_( void *mem, size_t size,
 /* ---------- */
       new->polarlong = astReadDouble( channel, "plrlg", AST__BAD );
       if ( TestPolarLong( new, status ) ) SetPolarLong( new, new->polarlong, status );
+      new->use_simd = -1;
 
    }
 

--- a/src/sphmap.c
+++ b/src/sphmap.c
@@ -1296,10 +1296,12 @@ static void TransformLoopSIMD( AstMapping *this, int forward, int npoint,
 *     Two-pass approach: a #pragma omp simd pass dispatches atan2/sqrt
 *     (forward) or sin/cos (inverse) through libmvec, followed by a scalar
 *     fixup pass for bad values and poles.  Falls back to TransformLoopScalar
-*     for small batches (N < 8) or when UseSIMD is 0.
+*     for small batches (N < 8), when UseSIMD is 0, or when SIMD has been
+*     disabled globally for this thread.
 */
 
 /* Local Variables: */
+   AstSphMap *map;               /* Pointer to SphMap structure */
    double *p0;                   /* x / longitude input */
    double *p1;                   /* y / latitude input */
    double *p2;                   /* z input (forward only) */
@@ -1308,16 +1310,25 @@ static void TransformLoopSIMD( AstMapping *this, int forward, int npoint,
    double mxerr;                 /* Threshold for pole detection */
    double polarlong;             /* PolarLong attribute value */
    int point;                    /* Per-point loop counter */
+   int use_simd;                 /* Use the SIMD code path? */
+   double x;                     /* Cartesian coordinate values and distance */
+   double y;
+   double z;
+   double d2;
+   double theta;                 /* Spherical coordinate values */
+   double phi;
+   double cosphi;                /* Cosine of phi */
 
-/* Fall back for small N or when UseSIMD is disabled. */
-   {
-      AstSphMap *map = (AstSphMap *) this;
-      int use_simd = ( map->use_simd == -1 ) ? 1 : map->use_simd;
-      if( npoint < 8 || !use_simd ) {
-         TransformLoopScalar( this, forward, npoint, ncoord_in, ncoord_out,
-                              ptr_in, ptr_out, status );
-         return;
-      }
+/* Determine whether the SIMD code path should be used for this Mapping. */
+   map = (AstSphMap *) this;
+   use_simd = ( map->use_simd == -1 ) ? 1 : map->use_simd;
+
+/* Fall back to the scalar path for small batches, when UseSIMD is disabled
+   for this Mapping, or when SIMD has been disabled globally for this thread. */
+   if( npoint < 8 || !use_simd || astSIMDDisabled() ) {
+      TransformLoopScalar( this, forward, npoint, ncoord_in, ncoord_out,
+                           ptr_in, ptr_out, status );
+      return;
    }
 
    if( forward ){
@@ -1331,10 +1342,10 @@ static void TransformLoopSIMD( AstMapping *this, int forward, int npoint,
 /* speculative trig on all points via libmvec. */
       #pragma omp simd
       for( point = 0; point < npoint; point++ ) {
-         double x = p0[ point ];
-         double y = p1[ point ];
-         double z = p2[ point ];
-         double d2 = x*x + y*y;
+         x = p0[ point ];
+         y = p1[ point ];
+         z = p2[ point ];
+         d2 = x*x + y*y;
          q0[ point ] = atan2( y, x );
          q1[ point ] = atan2( z, sqrt( d2 ) );
       }
@@ -1372,11 +1383,11 @@ static void TransformLoopSIMD( AstMapping *this, int forward, int npoint,
 /* speculative sin/cos on all points via libmvec. */
       #pragma omp simd
       for( point = 0; point < npoint; point++ ) {
-         double theta = q0[ point ];
-         double phi   = q1[ point ];
-         double cp = cos( phi );
-         p0[ point ] = cos( theta ) * cp;
-         p1[ point ] = sin( theta ) * cp;
+         theta = q0[ point ];
+         phi = q1[ point ];
+         cosphi = cos( phi );
+         p0[ point ] = cos( theta ) * cosphi;
+         p1[ point ] = sin( theta ) * cosphi;
          p2[ point ] = sin( phi );
       }
 

--- a/src/sphmap.h
+++ b/src/sphmap.h
@@ -219,6 +219,7 @@ typedef struct AstSphMap {
 /* Attributes specific to objects in this class. */
    double polarlong;             /* Longitude to assign to either pole */
    int unitradius;               /* Are input vectors always of unit length? */
+   int use_simd;                 /* Use SIMD-vectorised transform? (-1=unset/default) */
 } AstSphMap;
 
 /* Virtual function table. */
@@ -244,6 +245,9 @@ typedef struct AstSphMapVtab {
    int (* TestPolarLong)( AstSphMap *, int * );
    void (* ClearPolarLong)( AstSphMap *, int * );
    void (* SetPolarLong)( AstSphMap *, double, int * );
+
+   void (*TransformLoop)( AstMapping *, int, int, int, int,
+                          double **, double **, int * );
 } AstSphMapVtab;
 
 #if defined(THREAD_SAFE)
@@ -305,6 +309,7 @@ double astGetPolarLong_( AstSphMap *, int * );
 int astTestPolarLong_( AstSphMap *, int * );
 void astClearPolarLong_( AstSphMap *, int * );
 void astSetPolarLong_( AstSphMap *, double, int * );
+
 #endif
 
 /* Function interfaces. */
@@ -364,6 +369,7 @@ astINVOKE(O,astLoadSphMap_(mem,size,vtab,name,astCheckChannel(channel),STATUS_PT
 #define astGetPolarLong(this)       astINVOKE(V,astGetPolarLong_(astCheckSphMap(this),STATUS_PTR))
 #define astSetPolarLong(this,value) astINVOKE(V,astSetPolarLong_(astCheckSphMap(this),value,STATUS_PTR))
 #define astTestPolarLong(this)      astINVOKE(V,astTestPolarLong_(astCheckSphMap(this),STATUS_PTR))
+
 #endif
 
 #endif


### PR DESCRIPTION
## Background

A couple weeks ago I was doing some benchmarking of AST (wrapped in my libasdf-gwcs library) against the Python GWCS package.  I found, to no surprise, that for many cases AST far outperformed Python (on a single thread).  However, at about N=100000 points the Python code started to outperform slightly.

I concluded that this was due to NumPy's built-in SIMD support for many of its ufuncs (and potentially BLAS as well, though I don't think that was a major contributor since there are only some small matrix multiplications performed).  On my machine N=100000 happened to be where the Python overhead is amortized by the SIMD enhancements.

I found that the major contributors in my case were PolyMap, MatrixMap, and SphMap, with the biggest potential win coming from SphMap.  So I set about adding some bare minimum compiler (GCC) generated vectorization in targeted areas to see if we could get any quick wins, starting with SphMap, and indeed it did make a big difference.

I've added a little benchmark program adapted from my libasdf-gwcs benchmark.  I then went on to see if I could get any easy wins with MatrixMap and PolyMap.  These were a little trickier to get right, especially PolyMap.  The key observation in all these cases is that the main outer loop of each `Transform` method is over the input points.  In a way this makes sense for cache efficiency, but ignoring that for the first pass I trudged ahead, and did close the gap with Python up to a point--eventually at even larger N the performance was being dominated by DRAM moves.

At least for MatrixMap and PolyMap I added a utility function to return the system's L2 cache size (should work for any current x86-64, YMMV on other platforms), and add a separate outer loop to chunk the points into sets small enough to fit in cache (assuming not huge numbers of polynomial coeffs or matrix elements, other overhead), and this proved a big win--AST at parity with or better than NumPy, with near consistent throughput and memory usage even for large N.

## End-to-end impact (libasdf-gwcs vs Python GWCS)

The real motivation, and the most representative measurement, is full Roman WCS evaluation through libasdf-gwcs (which drives AST's `astTran2` over a complete WCS pipeline on real Roman L2 calibration files).  The plots below show single-thread throughput vs Python GWCS across N, before and after this change.

Before:

<img width="1200" height="750" alt="throughput" src="https://github.com/user-attachments/assets/927073ea-b75b-4b64-a273-6c4ad3eaea49" />

After, with AST compiled with SIMD features:

<img width="1200" height="750" alt="libasdf-gwcs vs Python GWCS -- after AST SIMD" src="https://github.com/user-attachments/assets/a50d116c-4e7a-408d-8ee8-94571cd330b9" />

The above was just from one run of the benchmark but YMMV. In effect this closes the gap with NumPy, and I had some runs depending on the conditions that outperformed it entirely.

The per-transform microbenchmarks further down isolate where the gains come from; this end-to-end view is what actually matters for a WCS pipeline, and is also where the L2 chunking pays off most (each pipeline stage's output stays cache-resident as the next stage's input, rather than being re-streamed from DRAM).

## What's in this PR

- **Opt-in build flag.**  A new `AST_ENABLE_SIMD` option (CMake and autotools), **OFF by default**.  When enabled, SIMD-friendly compiler flags (`-fopenmp-simd -ffast-math -fno-associative-math -march=x86-64-v3`) are applied *only* to `sphmap.c`, `polymap.c` and `matrixmap.c`, so the floating-point semantics of the rest of the library are unchanged.  The flags are only accepted on a GCC/glibc toolchain that supports them; otherwise the option is a no-op.

- **`TransformLoop` vtable slot.**  Each of SphMap, PolyMap and MatrixMap gains a per-class `TransformLoop` slot.  `Transform` is now a thin wrapper (validation, invert handling, point extraction) that dispatches to either `TransformLoopScalar` or `TransformLoopSIMD`.  This keeps the scalar and vectorized inner loops cleanly separated instead of `#ifdef`-ing through the body of `Transform`.

- **Runtime `UseSIMD` attribute.**  A per-instance integer attribute on each of those classes (default 1 when built with SIMD support, 0 otherwise) lets a caller force the scalar path at runtime -- useful for bit-exact reproducibility or debugging without rebuilding.  Setting `UseSIMD=1` on a library built without SIMD reports `AST__ATSER`.  The attribute is deliberately not serialized (it's just a runtime tuning knob, not part of the mapping description).  I debated making this some kind of global setting but opted to make it specific to the supported transforms for now.

  - Between `TransformLoop` and `UseSIMD` there's a bunch of duplicative code.  I didn't want to do any more refactoring for now before waiting to see what you have to say about this, but it seems to merit a base class or even just moved into the base `Mapping` class.

- **`astCPUCacheSize(level)`** in `memory.c`: returns the L1D/L2/L3 cache size via CPUID (x86-64), with a `sysconf` fallback and hard-coded defaults.  PolyMap and MatrixMap use the L2 size to pick a chunk size.

- **The vectorized kernels** themselves (the substance):
  - *SphMap* -- inline `atan2`/`sqrt` (forward) and `sin`/`cos` (inverse) under `#pragma omp simd`, which GCC routes through glibc `libmvec`; a scalar fixup pass handles poles and bad values.
  - *PolyMap* -- invert the nested evaluation loops so the innermost loop is over points (terms become independent and vectorize); process points in L2-sized chunks so the per-power work buffers stay cache-resident.  Falls back to scalar for small N (where the per-call buffer setup dominates) and for ChebyMap (which overrides `PolyPowers`).  This could easily be extended to ChebyMap too but I skipped it for now since my usecase doesn't use any Chebychev polynomials, at least for now.
  - *MatrixMap* -- full matrix: point loop innermost, `VFMADD` via `#pragma omp simd`, L2 chunking, and a bad-value fixup that runs only when a vectorized scan finds a bad input; diagonal matrix: a branchless compare/blend.

- **`perf/bench_simd.c`** -- a standalone benchmark (details below).

## Benchmark

`perf/bench_simd` runs each transform twice in a single process -- scalar (`UseSIMD=0`) and SIMD (`UseSIMD=1`) via the runtime attribute -- over an N sweep, and prints a scalar-vs-SIMD summary (plain text, or `--markdown`).

A note on methodology, since it matters for reading the small-N numbers: each measurement times a *calibrated batch* of repeated `astTranP` calls (the batch grows until it runs for at least 20 ms) and reports the amortized per-call time.  At small N a single call is dominated by call overhead and clock resolution rather than throughput, so batching is what makes those rows meaningful -- it removes measurement *error*, not the per-call cost itself.  The input arrays stay hot across a batch, so small/medium N measures compute-bound throughput and large N (which exceeds the last-level cache) measures bandwidth-bound throughput.  Reported figures are the median over the reps (`-r`, default 5).

**Hardware/build for the numbers below:** Intel i7-7820HQ (Kaby Lake, AVX2), L2 = 1 MiB/core, L3 = 8 MiB; GCC 13.3.0 (i.e. just my laptop); `-DCMAKE_BUILD_TYPE=RelWithDebInfo -DAST_ENABLE_SIMD=ON`.

### Headline

| Transform | what it exercises | peak SIMD speedup | large-N (16.7M) |
|-----------|-------------------|------------------:|----------------:|
| `sphmap_fwd` | (x,y,z)->(lon,lat), `atan2`/`sqrt` | \~8.6x (N\~65K) | 8.4x |
| `sphmap_inv` | (lon,lat)->(x,y,z), `sin`/`cos` | \~6.9x (N\~16K) | 6.3x |
| `poly5_fwd` | degree-5 2-D PolyMap (SIP-like) | \~3.1x (N\~1K) | 2.9x |
| `poly1_fwd` | degree-1 2-D PolyMap (linear) | \~2.7x (N\~1K) | 2.4x |
| `matfull2_fwd` | 2x2 full MatrixMap (rotation) | \~4.5x (N\~4K) | 2.8x |
| `matdiag2_fwd` | 2x2 diagonal MatrixMap (scale) | \~1.8x (N\~4K) | 1.2x |

A few things worth calling out:

- **SphMap is the big win**, as expected -- almost all of its cost is transcendental math, and `libmvec` vectorizes that directly.
- **PolyMap** sustains ~2.5-3x across the useful range.
- **MatrixMap full** went from a modest gain to ~2.8-4.5x after restructuring the kernel to write each output once and skip the bad-value fixup on clean data.
- **MatrixMap diagonal** stays modest (~1.2x at large N) because it is a single-pass streaming kernel (one read, one multiply, one write per element, no data reuse).  At large N it is simply DRAM-bandwidth-bound, and chunking cannot reduce its mandatory traffic -- this is expected, not a regression.
- Below N~16-32 the SIMD path is at best a wash; PolyMap explicitly falls back to scalar there, and the others come out ~1.0x.

### Full sweep

<details>
<summary>scalar vs SIMD, Mpx/s, N = 1 ... 16.7M (median of 9 reps)</summary>

| Transform | N | Scalar Mpx/s | SIMD Mpx/s | Speedup |
|-----------|--:|-------------:|-----------:|--------:|
| sphmap_fwd | 1 | 1.1 | 1.0 | 0.90x |
| sphmap_fwd | 4 | 3.5 | 3.4 | 0.97x |
| sphmap_fwd | 8 | 6.3 | 7.5 | 1.20x |
| sphmap_fwd | 16 | 9.3 | 16.5 | 1.77x |
| sphmap_fwd | 32 | 11.5 | 27.0 | 2.35x |
| sphmap_fwd | 64 | 14.2 | 42.8 | 3.01x |
| sphmap_fwd | 128 | 15.1 | 58.9 | 3.90x |
| sphmap_fwd | 256 | 14.9 | 83.3 | 5.60x |
| sphmap_fwd | 512 | 13.7 | 90.7 | 6.62x |
| sphmap_fwd | 1024 | 13.3 | 100.1 | 7.51x |
| sphmap_fwd | 4096 | 12.6 | 103.9 | 8.26x |
| sphmap_fwd | 16384 | 13.3 | 113.5 | 8.55x |
| sphmap_fwd | 65536 | 12.8 | 109.6 | 8.58x |
| sphmap_fwd | 262144 | 12.7 | 109.9 | 8.64x |
| sphmap_fwd | 1048576 | 12.9 | 106.5 | 8.25x |
| sphmap_fwd | 4194304 | 12.8 | 107.2 | 8.40x |
| sphmap_fwd | 16711744 | 12.4 | 104.1 | 8.41x |
| sphmap_inv | 1 | 1.1 | 1.1 | 1.02x |
| sphmap_inv | 4 | 4.0 | 4.1 | 1.01x |
| sphmap_inv | 8 | 7.0 | 8.9 | 1.28x |
| sphmap_inv | 16 | 10.5 | 16.4 | 1.56x |
| sphmap_inv | 32 | 14.7 | 28.5 | 1.94x |
| sphmap_inv | 64 | 18.2 | 43.2 | 2.38x |
| sphmap_inv | 128 | 20.8 | 65.7 | 3.16x |
| sphmap_inv | 256 | 21.6 | 87.2 | 4.03x |
| sphmap_inv | 512 | 21.9 | 101.6 | 4.63x |
| sphmap_inv | 1024 | 18.0 | 107.3 | 5.95x |
| sphmap_inv | 4096 | 17.1 | 114.8 | 6.70x |
| sphmap_inv | 16384 | 17.3 | 119.2 | 6.89x |
| sphmap_inv | 65536 | 18.0 | 119.0 | 6.62x |
| sphmap_inv | 262144 | 17.5 | 111.2 | 6.36x |
| sphmap_inv | 1048576 | 17.6 | 110.9 | 6.30x |
| sphmap_inv | 4194304 | 16.4 | 110.0 | 6.69x |
| sphmap_inv | 16711744 | 16.9 | 106.0 | 6.26x |
| poly5_fwd | 1 | 0.9 | 0.9 | 0.96x |
| poly5_fwd | 4 | 3.1 | 3.3 | 1.04x |
| poly5_fwd | 8 | 5.5 | 5.6 | 1.02x |
| poly5_fwd | 16 | 9.0 | 9.1 | 1.01x |
| poly5_fwd | 32 | 12.3 | 15.5 | 1.26x |
| poly5_fwd | 64 | 14.4 | 26.3 | 1.83x |
| poly5_fwd | 128 | 16.6 | 41.8 | 2.51x |
| poly5_fwd | 256 | 19.5 | 55.5 | 2.84x |
| poly5_fwd | 512 | 19.8 | 61.6 | 3.11x |
| poly5_fwd | 1024 | 20.6 | 64.7 | 3.14x |
| poly5_fwd | 4096 | 20.9 | 62.1 | 2.97x |
| poly5_fwd | 16384 | 21.7 | 62.4 | 2.88x |
| poly5_fwd | 65536 | 22.1 | 62.4 | 2.82x |
| poly5_fwd | 262144 | 22.4 | 60.5 | 2.70x |
| poly5_fwd | 1048576 | 20.9 | 59.8 | 2.86x |
| poly5_fwd | 4194304 | 21.3 | 59.9 | 2.81x |
| poly5_fwd | 16711744 | 20.6 | 59.6 | 2.89x |
| poly1_fwd | 1 | 0.9 | 1.0 | 1.03x |
| poly1_fwd | 4 | 3.6 | 3.5 | 0.97x |
| poly1_fwd | 8 | 6.3 | 6.2 | 0.98x |
| poly1_fwd | 16 | 10.9 | 10.2 | 0.94x |
| poly1_fwd | 32 | 15.9 | 18.8 | 1.18x |
| poly1_fwd | 64 | 23.2 | 33.9 | 1.46x |
| poly1_fwd | 128 | 28.0 | 53.5 | 1.91x |
| poly1_fwd | 256 | 31.9 | 72.7 | 2.28x |
| poly1_fwd | 512 | 34.3 | 88.8 | 2.59x |
| poly1_fwd | 1024 | 37.2 | 101.9 | 2.74x |
| poly1_fwd | 4096 | 37.7 | 99.2 | 2.63x |
| poly1_fwd | 16384 | 39.3 | 97.8 | 2.49x |
| poly1_fwd | 65536 | 39.9 | 99.4 | 2.49x |
| poly1_fwd | 262144 | 38.9 | 95.2 | 2.45x |
| poly1_fwd | 1048576 | 38.8 | 89.9 | 2.31x |
| poly1_fwd | 4194304 | 36.3 | 93.1 | 2.56x |
| poly1_fwd | 16711744 | 38.5 | 93.2 | 2.42x |
| matdiag2_fwd | 1 | 1.1 | 1.2 | 1.11x |
| matdiag2_fwd | 4 | 4.2 | 4.5 | 1.07x |
| matdiag2_fwd | 8 | 9.0 | 8.7 | 0.97x |
| matdiag2_fwd | 16 | 15.9 | 17.0 | 1.07x |
| matdiag2_fwd | 32 | 36.2 | 33.6 | 0.93x |
| matdiag2_fwd | 64 | 67.6 | 69.4 | 1.03x |
| matdiag2_fwd | 128 | 125.6 | 130.2 | 1.04x |
| matdiag2_fwd | 256 | 215.3 | 252.8 | 1.17x |
| matdiag2_fwd | 512 | 335.3 | 412.4 | 1.23x |
| matdiag2_fwd | 1024 | 457.4 | 679.5 | 1.49x |
| matdiag2_fwd | 4096 | 622.1 | 1103.5 | 1.77x |
| matdiag2_fwd | 16384 | 694.0 | 1007.3 | 1.45x |
| matdiag2_fwd | 65536 | 660.9 | 1063.3 | 1.61x |
| matdiag2_fwd | 262144 | 587.7 | 736.7 | 1.25x |
| matdiag2_fwd | 1048576 | 441.7 | 543.6 | 1.23x |
| matdiag2_fwd | 4194304 | 437.1 | 505.2 | 1.16x |
| matdiag2_fwd | 16711744 | 438.1 | 508.4 | 1.16x |
| matfull2_fwd | 1 | 1.2 | 1.0 | 0.83x |
| matfull2_fwd | 4 | 4.7 | 4.4 | 0.94x |
| matfull2_fwd | 8 | 8.4 | 8.4 | 0.99x |
| matfull2_fwd | 16 | 14.5 | 16.9 | 1.16x |
| matfull2_fwd | 32 | 28.8 | 35.1 | 1.22x |
| matfull2_fwd | 64 | 46.7 | 63.8 | 1.37x |
| matfull2_fwd | 128 | 64.1 | 122.7 | 1.91x |
| matfull2_fwd | 256 | 83.3 | 216.8 | 2.60x |
| matfull2_fwd | 512 | 100.9 | 338.4 | 3.35x |
| matfull2_fwd | 1024 | 108.7 | 428.4 | 3.94x |
| matfull2_fwd | 4096 | 113.2 | 509.3 | 4.50x |
| matfull2_fwd | 16384 | 117.2 | 488.2 | 4.16x |
| matfull2_fwd | 65536 | 118.7 | 493.8 | 4.16x |
| matfull2_fwd | 262144 | 118.6 | 407.8 | 3.44x |
| matfull2_fwd | 1048576 | 117.9 | 334.9 | 2.84x |
| matfull2_fwd | 4194304 | 116.7 | 328.2 | 2.80x |
| matfull2_fwd | 16711744 | 115.5 | 323.2 | 2.80x |

</details>

## Correctness and testing

- The full CMake `ctest` suite passes; the only failures are ones that pre-date this branch and are unrelated to it.
- The SIMD paths are **not** bit-for-bit identical to the scalar paths (`-ffast-math` lets GCC call `libmvec`, whose x86_64 vector math functions are documented to within 4 ULP, so a result can differ from scalar `libm` by a few ULP).  This is normally irrelevant. The one test I ran that was sensitive to that (`grid_car3`) runs with `UseSIMD=0` so it stays bit-exact against its committed reference; the rest of the suite runs with SIMD enabled.
- Built and run clean under `-Wall`-style warnings and ASan/UBSan (no new warnings, no sanitizer findings) in addition to the normal `RelWithDebInfo` build.

## Caveats and limitations

- This is currently wired up and tested only for **GCC + glibc on x86-64**: the build gates on a GNU compiler and the `-march=x86-64-v3` flag, and `AST_ENABLE_SIMD` is off by default, so on any other toolchain it is simply a no-op.  Clang can almost certainly do the same (it also supports vector-ABI / `libmvec` math), but I haven't tested it with Clang at all yet.  glibc also ships a `libmvec` for aarch64 these days, but this build isn't set up or tested for that either.
- `astCPUCacheSize`'s CPUID path is x86-64; elsewhere it falls back to `sysconf` and then to conservative defaults (L1 32 KiB, L2 512 KiB, L3 8 MiB).
- Single-threaded, every transform is ultimately DRAM-bandwidth-bound at large enough N (the diagonal MatrixMap reaches that point almost immediately).  Going beyond that needs either threading (more memory bandwidth) or pipeline fusion so intermediate results are consumed while still cache-hot -- the latter is exactly what the end-to-end libasdf-gwcs path benefits from, and is left for future work.
