### PR TITLE
Handle DBL_DECIMAL_DIG inconsistency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,10 +39,11 @@ option(BUILD_TESTING "Build the test program" ON)
 
 # Pick the C standard libast is built against.  The legacy Starlink build
 # declared C99; C11 is source-compatible (no removed APIs, no keyword
-# collisions) and has the advantage that `DBL_DECIMAL_DIG` is visible on
-# glibc under strict ISO mode, which keeps the number of digits used in
-# AST's serialized output (`AST__DBL_DIG`) consistent across macOS and
-# Linux.  Default stays "99" until the project broadly adopts C11.
+# collisions).  The number of digits used in AST's serialized output
+# (`AST__DBL_DIG`) no longer depends on this choice: under C11 it comes
+# from `DBL_DECIMAL_DIG`, and the C99 fallback (`DBL_DIG + 2`) is defined
+# to equal it for IEEE-754 binary64, so output is identical (17 digits)
+# either way.  Default stays "99" until the project broadly adopts C11.
 set(AST_C_STANDARD "99" CACHE STRING "C standard for libast (99 or 11)")
 set_property(CACHE AST_C_STANDARD PROPERTY STRINGS "99" "11")
 

--- a/ast_tester/gen_simplify_fixtures.c
+++ b/ast_tester/gen_simplify_fixtures.c
@@ -58,7 +58,7 @@ static void gen_zoom_fixtures(const char *dir) {
 
     /* zoommap-03: single inverted ZoomMap normalizes */
     {
-        AstZoomMap *zm = astZoomMap(2, 2.0, "");
+        AstZoomMap *zm = astZoomMap(2, 2.0, " ");
         astInvert(zm);
         write_fixture(dir, "zoom_invert_normalize", (AstMapping*)zm);
         zm = astAnnul(zm);
@@ -66,18 +66,18 @@ static void gen_zoom_fixtures(const char *dir) {
 
     /* zoommap-05: parallel all-unit → UnitMap */
     {
-        AstUnitMap *um = astUnitMap(2, "");
-        AstZoomMap *zm = astZoomMap(3, 1.0, "");
-        AstCmpMap *cm = astCmpMap(um, zm, 0, "");
+        AstUnitMap *um = astUnitMap(2, " ");
+        AstZoomMap *zm = astZoomMap(3, 1.0, " ");
+        AstCmpMap *cm = astCmpMap(um, zm, 0, " ");
         write_fixture(dir, "zoom_parallel_all_unit", (AstMapping*)cm);
         cm = astAnnul(cm); um = astAnnul(um); zm = astAnnul(zm);
     }
 
     /* zoommap-06: parallel same factor → single ZoomMap */
     {
-        AstZoomMap *z1 = astZoomMap(1, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(2, 2.0, "");
-        AstCmpMap *cm = astCmpMap(z1, z2, 0, "");
+        AstZoomMap *z1 = astZoomMap(1, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(2, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(z1, z2, 0, " ");
         write_fixture(dir, "zoom_parallel_same_factor", (AstMapping*)cm);
         cm = astAnnul(cm); z1 = astAnnul(z1); z2 = astAnnul(z2);
     }
@@ -85,9 +85,9 @@ static void gen_zoom_fixtures(const char *dir) {
     /* zoommap-09: absorb into previous MatrixMap */
     {
         double diag[] = {3.0, 5.0};
-        AstMatrixMap *mm = astMatrixMap(2, 2, 1, diag, "");
-        AstZoomMap *zm = astZoomMap(2, 2.0, "");
-        AstCmpMap *cm = astCmpMap(mm, zm, 1, "");
+        AstMatrixMap *mm = astMatrixMap(2, 2, 1, diag, " ");
+        AstZoomMap *zm = astZoomMap(2, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(mm, zm, 1, " ");
         write_fixture(dir, "zoom_absorb_prev_matrix", (AstMapping*)cm);
         cm = astAnnul(cm); mm = astAnnul(mm); zm = astAnnul(zm);
     }
@@ -96,9 +96,9 @@ static void gen_zoom_fixtures(const char *dir) {
     {
         double ina[] = {0, 0}, inb[] = {1, 1};
         double outa[] = {1, 2}, outb[] = {4, 6};
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstZoomMap *zm = astZoomMap(2, 2.0, "");
-        AstCmpMap *cm = astCmpMap(wm, zm, 1, "");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstZoomMap *zm = astZoomMap(2, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(wm, zm, 1, " ");
         write_fixture(dir, "zoom_absorb_prev_win", (AstMapping*)cm);
         cm = astAnnul(cm); wm = astAnnul(wm); zm = astAnnul(zm);
     }
@@ -106,9 +106,9 @@ static void gen_zoom_fixtures(const char *dir) {
     /* zoommap-11: absorb into previous ShiftMap */
     {
         double shifts[] = {3.0, 5.0};
-        AstShiftMap *sm = astShiftMap(2, shifts, "");
-        AstZoomMap *zm = astZoomMap(2, 2.0, "");
-        AstCmpMap *cm = astCmpMap(sm, zm, 1, "");
+        AstShiftMap *sm = astShiftMap(2, shifts, " ");
+        AstZoomMap *zm = astZoomMap(2, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(sm, zm, 1, " ");
         write_fixture(dir, "zoom_absorb_prev_shift", (AstMapping*)cm);
         cm = astAnnul(cm); sm = astAnnul(sm); zm = astAnnul(zm);
     }
@@ -116,9 +116,9 @@ static void gen_zoom_fixtures(const char *dir) {
     /* zoommap-12: absorb into next MatrixMap */
     {
         double diag[] = {3.0, 5.0};
-        AstZoomMap *zm = astZoomMap(2, 2.0, "");
-        AstMatrixMap *mm = astMatrixMap(2, 2, 1, diag, "");
-        AstCmpMap *cm = astCmpMap(zm, mm, 1, "");
+        AstZoomMap *zm = astZoomMap(2, 2.0, " ");
+        AstMatrixMap *mm = astMatrixMap(2, 2, 1, diag, " ");
+        AstCmpMap *cm = astCmpMap(zm, mm, 1, " ");
         write_fixture(dir, "zoom_absorb_next_matrix", (AstMapping*)cm);
         cm = astAnnul(cm); zm = astAnnul(zm); mm = astAnnul(mm);
     }
@@ -127,9 +127,9 @@ static void gen_zoom_fixtures(const char *dir) {
     {
         double ina[] = {0, 0}, inb[] = {1, 1};
         double outa[] = {1, 2}, outb[] = {4, 6};
-        AstZoomMap *zm = astZoomMap(2, 2.0, "");
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstCmpMap *cm = astCmpMap(zm, wm, 1, "");
+        AstZoomMap *zm = astZoomMap(2, 2.0, " ");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstCmpMap *cm = astCmpMap(zm, wm, 1, " ");
         write_fixture(dir, "zoom_absorb_next_win", (AstMapping*)cm);
         cm = astAnnul(cm); zm = astAnnul(zm); wm = astAnnul(wm);
     }
@@ -137,9 +137,9 @@ static void gen_zoom_fixtures(const char *dir) {
     /* zoommap-14: absorb into next ShiftMap */
     {
         double shifts[] = {3.0, 5.0};
-        AstZoomMap *zm = astZoomMap(2, 2.0, "");
-        AstShiftMap *sm = astShiftMap(2, shifts, "");
-        AstCmpMap *cm = astCmpMap(zm, sm, 1, "");
+        AstZoomMap *zm = astZoomMap(2, 2.0, " ");
+        AstShiftMap *sm = astShiftMap(2, shifts, " ");
+        AstCmpMap *cm = astCmpMap(zm, sm, 1, " ");
         write_fixture(dir, "zoom_absorb_next_shift", (AstMapping*)cm);
         cm = astAnnul(cm); zm = astAnnul(zm); sm = astAnnul(sm);
     }
@@ -154,9 +154,9 @@ static void gen_win_fixtures(const char *dir) {
     {
         double ina[] = {0}, inb[] = {1}, outa[] = {3}, outb[] = {5};
         double ina2[] = {0}, inb2[] = {1}, outa2[] = {5}, outb2[] = {9};
-        AstWinMap *w1 = astWinMap(1, ina, inb, outa, outb, "");
-        AstWinMap *w2 = astWinMap(1, ina2, inb2, outa2, outb2, "");
-        AstCmpMap *cm = astCmpMap(w1, w2, 1, "");
+        AstWinMap *w1 = astWinMap(1, ina, inb, outa, outb, " ");
+        AstWinMap *w2 = astWinMap(1, ina2, inb2, outa2, outb2, " ");
+        AstCmpMap *cm = astCmpMap(w1, w2, 1, " ");
         write_fixture(dir, "win_win_series_merge", (AstMapping*)cm);
         cm = astAnnul(cm); w1 = astAnnul(w1); w2 = astAnnul(w2);
     }
@@ -164,9 +164,9 @@ static void gen_win_fixtures(const char *dir) {
     /* winmap-07: ZoomMap + WinMap series (reverse order) */
     {
         double ina[] = {0}, inb[] = {1}, outa[] = {5}, outb[] = {7};
-        AstZoomMap *zm = astZoomMap(1, 3.0, "");
-        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, "");
-        AstCmpMap *cm = astCmpMap(zm, wm, 1, "");
+        AstZoomMap *zm = astZoomMap(1, 3.0, " ");
+        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, " ");
+        AstCmpMap *cm = astCmpMap(zm, wm, 1, " ");
         write_fixture(dir, "win_zoom_series_merge_rev", (AstMapping*)cm);
         cm = astAnnul(cm); zm = astAnnul(zm); wm = astAnnul(wm);
     }
@@ -175,9 +175,9 @@ static void gen_win_fixtures(const char *dir) {
     {
         double shifts[] = {3.0};
         double ina[] = {0}, inb[] = {1}, outa[] = {5}, outb[] = {7};
-        AstShiftMap *sm = astShiftMap(1, shifts, "");
-        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, "");
-        AstCmpMap *cm = astCmpMap(sm, wm, 1, "");
+        AstShiftMap *sm = astShiftMap(1, shifts, " ");
+        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, " ");
+        AstCmpMap *cm = astCmpMap(sm, wm, 1, " ");
         write_fixture(dir, "win_shift_series_merge_rev", (AstMapping*)cm);
         cm = astAnnul(cm); sm = astAnnul(sm); wm = astAnnul(wm);
     }
@@ -186,9 +186,9 @@ static void gen_win_fixtures(const char *dir) {
     {
         double diag[] = {3.0, 5.0};
         double ina[] = {0, 0}, inb[] = {1, 1}, outa[] = {1, 2}, outb[] = {5, 8};
-        AstMatrixMap *mm = astMatrixMap(2, 2, 1, diag, "");
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstCmpMap *cm = astCmpMap(mm, wm, 1, "");
+        AstMatrixMap *mm = astMatrixMap(2, 2, 1, diag, " ");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstCmpMap *cm = astCmpMap(mm, wm, 1, " ");
         write_fixture(dir, "win_matrix_series_merge_rev", (AstMapping*)cm);
         cm = astAnnul(cm); mm = astAnnul(mm); wm = astAnnul(wm);
     }
@@ -196,9 +196,9 @@ static void gen_win_fixtures(const char *dir) {
     /* winmap-12: WinMap + UnitMap series */
     {
         double ina[] = {0, 0}, inb[] = {1, 1}, outa[] = {3, 5}, outb[] = {5, 9};
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstUnitMap *um = astUnitMap(2, "");
-        AstCmpMap *cm = astCmpMap(wm, um, 1, "");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstUnitMap *um = astUnitMap(2, " ");
+        AstCmpMap *cm = astCmpMap(wm, um, 1, " ");
         write_fixture(dir, "win_unit_series_merge", (AstMapping*)cm);
         cm = astAnnul(cm); wm = astAnnul(wm); um = astAnnul(um);
     }
@@ -207,9 +207,9 @@ static void gen_win_fixtures(const char *dir) {
     {
         double ina[] = {0}, inb[] = {1}, outa[] = {3}, outb[] = {5};
         double ina2[] = {0}, inb2[] = {1}, outa2[] = {7}, outb2[] = {11};
-        AstWinMap *w1 = astWinMap(1, ina, inb, outa, outb, "");
-        AstWinMap *w2 = astWinMap(1, ina2, inb2, outa2, outb2, "");
-        AstCmpMap *cm = astCmpMap(w1, w2, 0, "");
+        AstWinMap *w1 = astWinMap(1, ina, inb, outa, outb, " ");
+        AstWinMap *w2 = astWinMap(1, ina2, inb2, outa2, outb2, " ");
+        AstCmpMap *cm = astCmpMap(w1, w2, 0, " ");
         write_fixture(dir, "win_win_parallel_merge", (AstMapping*)cm);
         cm = astAnnul(cm); w1 = astAnnul(w1); w2 = astAnnul(w2);
     }
@@ -217,9 +217,9 @@ static void gen_win_fixtures(const char *dir) {
     /* winmap-30: WinMap + ZoomMap parallel */
     {
         double ina[] = {0}, inb[] = {1}, outa[] = {3}, outb[] = {5};
-        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, "");
-        AstZoomMap *zm = astZoomMap(1, 4.0, "");
-        AstCmpMap *cm = astCmpMap(wm, zm, 0, "");
+        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, " ");
+        AstZoomMap *zm = astZoomMap(1, 4.0, " ");
+        AstCmpMap *cm = astCmpMap(wm, zm, 0, " ");
         write_fixture(dir, "win_zoom_parallel_merge", (AstMapping*)cm);
         cm = astAnnul(cm); wm = astAnnul(wm); zm = astAnnul(zm);
     }
@@ -228,9 +228,9 @@ static void gen_win_fixtures(const char *dir) {
     {
         double ina[] = {0}, inb[] = {1}, outa[] = {3}, outb[] = {5};
         double diag[] = {7.0};
-        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, "");
-        AstMatrixMap *mm = astMatrixMap(1, 1, 1, diag, "");
-        AstCmpMap *cm = astCmpMap(wm, mm, 0, "");
+        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, " ");
+        AstMatrixMap *mm = astMatrixMap(1, 1, 1, diag, " ");
+        AstCmpMap *cm = astCmpMap(wm, mm, 0, " ");
         write_fixture(dir, "win_diagmatrix_parallel_merge", (AstMapping*)cm);
         cm = astAnnul(cm); wm = astAnnul(wm); mm = astAnnul(mm);
     }
@@ -238,9 +238,9 @@ static void gen_win_fixtures(const char *dir) {
     /* winmap-36: WinMap + UnitMap parallel */
     {
         double ina[] = {0}, inb[] = {1}, outa[] = {3}, outb[] = {5};
-        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, "");
-        AstUnitMap *um = astUnitMap(1, "");
-        AstCmpMap *cm = astCmpMap(wm, um, 0, "");
+        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, " ");
+        AstUnitMap *um = astUnitMap(1, " ");
+        AstCmpMap *cm = astCmpMap(wm, um, 0, " ");
         write_fixture(dir, "win_unit_parallel_merge", (AstMapping*)cm);
         cm = astAnnul(cm); wm = astAnnul(wm); um = astAnnul(um);
     }
@@ -248,9 +248,9 @@ static void gen_win_fixtures(const char *dir) {
     /* winmap-31: ZoomMap + WinMap in parallel (ZoomMap first) */
     {
         double ina[] = {0}, inb[] = {1}, outa[] = {3}, outb[] = {5};
-        AstZoomMap *zm = astZoomMap(1, 4.0, "");
-        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, "");
-        AstCmpMap *cm = astCmpMap(zm, wm, 0, "");
+        AstZoomMap *zm = astZoomMap(1, 4.0, " ");
+        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, " ");
+        AstCmpMap *cm = astCmpMap(zm, wm, 0, " ");
         write_fixture(dir, "win_zoom_parallel_merge_rev", (AstMapping*)cm);
         cm = astAnnul(cm); zm = astAnnul(zm); wm = astAnnul(wm);
     }
@@ -259,9 +259,9 @@ static void gen_win_fixtures(const char *dir) {
     {
         double ina[] = {0}, inb[] = {1}, outa[] = {3}, outb[] = {5};
         double shifts[] = {7.0};
-        AstShiftMap *sm = astShiftMap(1, shifts, "");
-        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, "");
-        AstCmpMap *cm = astCmpMap(sm, wm, 0, "");
+        AstShiftMap *sm = astShiftMap(1, shifts, " ");
+        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, " ");
+        AstCmpMap *cm = astCmpMap(sm, wm, 0, " ");
         write_fixture(dir, "win_shift_parallel_merge_rev", (AstMapping*)cm);
         cm = astAnnul(cm); sm = astAnnul(sm); wm = astAnnul(wm);
     }
@@ -270,9 +270,9 @@ static void gen_win_fixtures(const char *dir) {
     {
         double ina[] = {0}, inb[] = {1}, outa[] = {3}, outb[] = {5};
         double diag[] = {7.0};
-        AstMatrixMap *mm = astMatrixMap(1, 1, 1, diag, "");
-        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, "");
-        AstCmpMap *cm = astCmpMap(mm, wm, 0, "");
+        AstMatrixMap *mm = astMatrixMap(1, 1, 1, diag, " ");
+        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, " ");
+        AstCmpMap *cm = astCmpMap(mm, wm, 0, " ");
         write_fixture(dir, "win_diagmatrix_parallel_merge_rev", (AstMapping*)cm);
         cm = astAnnul(cm); mm = astAnnul(mm); wm = astAnnul(wm);
     }
@@ -280,9 +280,9 @@ static void gen_win_fixtures(const char *dir) {
     /* winmap-37: UnitMap + WinMap in parallel (UnitMap first) */
     {
         double ina[] = {0}, inb[] = {1}, outa[] = {3}, outb[] = {5};
-        AstUnitMap *um = astUnitMap(1, "");
-        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, "");
-        AstCmpMap *cm = astCmpMap(um, wm, 0, "");
+        AstUnitMap *um = astUnitMap(1, " ");
+        AstWinMap *wm = astWinMap(1, ina, inb, outa, outb, " ");
+        AstCmpMap *cm = astCmpMap(um, wm, 0, " ");
         write_fixture(dir, "win_unit_parallel_merge_rev", (AstMapping*)cm);
         cm = astAnnul(cm); um = astAnnul(um); wm = astAnnul(wm);
     }
@@ -295,7 +295,7 @@ static void gen_unit_fixtures(const char *dir) {
 
     /* unitmap-01: single inverted UnitMap → clears invert */
     {
-        AstUnitMap *um = astUnitMap(2, "");
+        AstUnitMap *um = astUnitMap(2, " ");
         astInvert(um);
         write_fixture(dir, "unit_invert_clear", (AstMapping*)um);
         um = astAnnul(um);
@@ -311,9 +311,9 @@ static void gen_matrix_fixtures(const char *dir) {
     {
         double diag[] = {2.0, 3.0};
         double ina[] = {0, 0}, inb[] = {1, 1}, outa[] = {1, 2}, outb[] = {5, 8};
-        AstMatrixMap *mm = astMatrixMap(2, 2, 1, diag, "");
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstCmpMap *cm = astCmpMap(mm, wm, 1, "");
+        AstMatrixMap *mm = astMatrixMap(2, 2, 1, diag, " ");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstCmpMap *cm = astCmpMap(mm, wm, 1, " ");
         write_fixture(dir, "matrix_diagwin_series_merge", (AstMapping*)cm);
         cm = astAnnul(cm); mm = astAnnul(mm); wm = astAnnul(wm);
     }
@@ -321,9 +321,9 @@ static void gen_matrix_fixtures(const char *dir) {
     /* matrixmap-12: MatrixMap + UnitMap series → UnitMap eliminated */
     {
         double diag[] = {2.0, 3.0};
-        AstMatrixMap *mm = astMatrixMap(2, 2, 1, diag, "");
-        AstUnitMap *um = astUnitMap(2, "");
-        AstCmpMap *cm = astCmpMap(mm, um, 1, "");
+        AstMatrixMap *mm = astMatrixMap(2, 2, 1, diag, " ");
+        AstUnitMap *um = astUnitMap(2, " ");
+        AstCmpMap *cm = astCmpMap(mm, um, 1, " ");
         write_fixture(dir, "matrix_unit_series_merge", (AstMapping*)cm);
         cm = astAnnul(cm); mm = astAnnul(mm); um = astAnnul(um);
     }
@@ -336,13 +336,13 @@ static void gen_cmpmap_fixtures(const char *dir) {
 
     /* cmpmap-01: CmpMap self-simplifies (internal inverse pair cancels) */
     {
-        AstZoomMap *z1 = astZoomMap(2, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(2, 2.0, "");
+        AstZoomMap *z1 = astZoomMap(2, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(2, 2.0, " ");
         astInvert(z2);
-        AstCmpMap *inner = astCmpMap(z1, z2, 1, "");
+        AstCmpMap *inner = astCmpMap(z1, z2, 1, " ");
         double shifts[] = {1.0, 2.0};
-        AstShiftMap *sm = astShiftMap(2, shifts, "");
-        AstCmpMap *outer = astCmpMap(inner, sm, 1, "");
+        AstShiftMap *sm = astShiftMap(2, shifts, " ");
+        AstCmpMap *outer = astCmpMap(inner, sm, 1, " ");
         write_fixture(dir, "cmpmap_self_simplify", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         z1 = astAnnul(z1); z2 = astAnnul(z2); sm = astAnnul(sm);
@@ -356,9 +356,9 @@ static void gen_tranmap_fixtures(const char *dir) {
 
     /* tranmap-01: inverted TranMap → normalizes */
     {
-        AstZoomMap *z1 = astZoomMap(1, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(1, 0.5, "");
-        AstTranMap *tm = astTranMap(z1, z2, "");
+        AstZoomMap *z1 = astZoomMap(1, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(1, 0.5, " ");
+        AstTranMap *tm = astTranMap(z1, z2, " ");
         astInvert(tm);
         write_fixture(dir, "tranmap_invert_normalize", (AstMapping*)tm);
         tm = astAnnul(tm); z1 = astAnnul(z1); z2 = astAnnul(z2);
@@ -366,13 +366,13 @@ static void gen_tranmap_fixtures(const char *dir) {
 
     /* tranmap-02: TranMap with simplifiable components */
     {
-        AstZoomMap *za1 = astZoomMap(1, 2.0, "");
-        AstZoomMap *za2 = astZoomMap(1, 3.0, "");
-        AstCmpMap *fwd = astCmpMap(za1, za2, 1, "");
-        AstZoomMap *zb1 = astZoomMap(1, 0.5, "");
-        AstZoomMap *zb2 = astZoomMap(1, 2.0, "");
-        AstCmpMap *inv = astCmpMap(zb1, zb2, 1, "");
-        AstTranMap *tm = astTranMap(fwd, inv, "");
+        AstZoomMap *za1 = astZoomMap(1, 2.0, " ");
+        AstZoomMap *za2 = astZoomMap(1, 3.0, " ");
+        AstCmpMap *fwd = astCmpMap(za1, za2, 1, " ");
+        AstZoomMap *zb1 = astZoomMap(1, 0.5, " ");
+        AstZoomMap *zb2 = astZoomMap(1, 2.0, " ");
+        AstCmpMap *inv = astCmpMap(zb1, zb2, 1, " ");
+        AstTranMap *tm = astTranMap(fwd, inv, " ");
         write_fixture(dir, "tranmap_component_simplify", (AstMapping*)tm);
         tm = astAnnul(tm); fwd = astAnnul(fwd); inv = astAnnul(inv);
         za1 = astAnnul(za1); za2 = astAnnul(za2);
@@ -387,10 +387,10 @@ static void gen_ratemap_fixtures(const char *dir) {
 
     /* ratemap-01: RateMap with simplifiable interior */
     {
-        AstZoomMap *z1 = astZoomMap(2, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(2, 3.0, "");
-        AstCmpMap *inner = astCmpMap(z1, z2, 1, "");
-        AstRateMap *rm = astRateMap(inner, 1, 1, "");
+        AstZoomMap *z1 = astZoomMap(2, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(2, 3.0, " ");
+        AstCmpMap *inner = astCmpMap(z1, z2, 1, " ");
+        AstRateMap *rm = astRateMap(inner, 1, 1, " ");
         write_fixture(dir, "ratemap_simplify_interior", (AstMapping*)rm);
         rm = astAnnul(rm); inner = astAnnul(inner);
         z1 = astAnnul(z1); z2 = astAnnul(z2);
@@ -399,12 +399,12 @@ static void gen_ratemap_fixtures(const char *dir) {
     /* ratemap-02: forward RateMap + inverted RateMap (same encapsulated
        mapping) → cancel via inverse */
     {
-        AstZoomMap *z1 = astZoomMap(1, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(1, 2.0, "");
-        AstRateMap *r1 = astRateMap(z1, 1, 1, "");
-        AstRateMap *r2 = astRateMap(z2, 1, 1, "");
+        AstZoomMap *z1 = astZoomMap(1, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(1, 2.0, " ");
+        AstRateMap *r1 = astRateMap(z1, 1, 1, " ");
+        AstRateMap *r2 = astRateMap(z2, 1, 1, " ");
         astInvert(r2);
-        AstCmpMap *cm = astCmpMap(r1, r2, 1, "");
+        AstCmpMap *cm = astCmpMap(r1, r2, 1, " ");
         write_fixture(dir, "ratemap_inverse_cancel", (AstMapping*)cm);
         cm = astAnnul(cm); r1 = astAnnul(r1); r2 = astAnnul(r2);
         z1 = astAnnul(z1); z2 = astAnnul(z2);
@@ -418,7 +418,7 @@ static void gen_slamap_fixtures(const char *dir) {
 
     /* slamap-04: single inverted SlaMap normalizes */
     {
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "EQGAL", 0, NULL);
         astInvert(sm);
         write_fixture(dir, "sla_invert_normalize", (AstMapping*)sm);
@@ -428,7 +428,7 @@ static void gen_slamap_fixtures(const char *dir) {
     /* slamap-02: partial cancellation (3 steps, middle pair cancels) */
     {
         double beq[] = {1950.0};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "ADDET", 1, beq);
         astSlaAdd(sm, "SUBET", 1, beq);
         astSlaAdd(sm, "EQGAL", 0, NULL);
@@ -439,18 +439,18 @@ static void gen_slamap_fixtures(const char *dir) {
     /* slamap-03: multi-map merge without step reduction */
     {
         double beq[] = {1950.0};
-        AstSlaMap *s1 = astSlaMap(0, "");
+        AstSlaMap *s1 = astSlaMap(0, " ");
         astSlaAdd(s1, "ADDET", 1, beq);
-        AstSlaMap *s2 = astSlaMap(0, "");
+        AstSlaMap *s2 = astSlaMap(0, " ");
         astSlaAdd(s2, "EQGAL", 0, NULL);
-        AstCmpMap *cm = astCmpMap(s1, s2, 1, "");
+        AstCmpMap *cm = astCmpMap(s1, s2, 1, " ");
         write_fixture(dir, "sla_merge_no_cancel", (AstMapping*)cm);
         cm = astAnnul(cm); s1 = astAnnul(s1); s2 = astAnnul(s2);
     }
 
     /* slamap-08: 0-arg supergalactic */
     {
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "GALSUP", 0, NULL);
         astSlaAdd(sm, "SUPGAL", 0, NULL);
         write_fixture(dir, "sla_supergalactic_cancel", (AstMapping*)sm);
@@ -459,7 +459,7 @@ static void gen_slamap_fixtures(const char *dir) {
 
     /* slamap-09: 0-arg J2000 dynamical */
     {
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "J2000H", 0, NULL);
         astSlaAdd(sm, "HJ2000", 0, NULL);
         write_fixture(dir, "sla_j2000_cancel", (AstMapping*)sm);
@@ -469,7 +469,7 @@ static void gen_slamap_fixtures(const char *dir) {
     /* slamap-10: 1-arg E-terms */
     {
         double beq[] = {1950.0};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "ADDET", 1, beq);
         astSlaAdd(sm, "SUBET", 1, beq);
         write_fixture(dir, "sla_eterms_cancel", (AstMapping*)sm);
@@ -479,7 +479,7 @@ static void gen_slamap_fixtures(const char *dir) {
     /* slamap-11: 1-arg FK4/FK5 */
     {
         double beq[] = {1950.0};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "FK45Z", 1, beq);
         astSlaAdd(sm, "FK54Z", 1, beq);
         write_fixture(dir, "sla_fk45_cancel", (AstMapping*)sm);
@@ -489,7 +489,7 @@ static void gen_slamap_fixtures(const char *dir) {
     /* slamap-12: 1-arg ICRS/FK5 */
     {
         double args[] = {2000.0};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "HFK5Z", 1, args);
         astSlaAdd(sm, "FK5HZ", 1, args);
         write_fixture(dir, "sla_icrs_cancel", (AstMapping*)sm);
@@ -499,7 +499,7 @@ static void gen_slamap_fixtures(const char *dir) {
     /* slamap-13: 1-arg ecliptic */
     {
         double args[] = {2000.0};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "EQECL", 1, args);
         astSlaAdd(sm, "ECLEQ", 1, args);
         write_fixture(dir, "sla_ecliptic_cancel", (AstMapping*)sm);
@@ -510,7 +510,7 @@ static void gen_slamap_fixtures(const char *dir) {
     {
         double amp_args[] = {51544.0, 2000.0};
         double map_args[] = {2000.0, 51544.0};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "AMP", 2, amp_args);
         astSlaAdd(sm, "MAP", 2, map_args);
         write_fixture(dir, "sla_geocentric_cancel", (AstMapping*)sm);
@@ -520,7 +520,7 @@ static void gen_slamap_fixtures(const char *dir) {
     /* slamap-23: redundant precession (start==end) */
     {
         double args[] = {2000.0, 2000.0};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "PREC", 2, args);
         write_fixture(dir, "sla_prec_redundant", (AstMapping*)sm);
         sm = astAnnul(sm);
@@ -530,7 +530,7 @@ static void gen_slamap_fixtures(const char *dir) {
     {
         double args1[] = {1950.0, 1975.0};
         double args2[] = {1975.0, 2000.0};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "PREC", 2, args1);
         astSlaAdd(sm, "PREC", 2, args2);
         write_fixture(dir, "sla_prec_merge", (AstMapping*)sm);
@@ -546,7 +546,7 @@ static void gen_specmap_fixtures(const char *dir) {
     /* specmap-04: single inverted SpecMap normalizes */
     {
         double rf[] = {1.4e9, 0.0};
-        AstSpecMap *sm = astSpecMap(1, 0, "");
+        AstSpecMap *sm = astSpecMap(1, 0, " ");
         astSpecAdd(sm, "FRTOVL", 1, rf);
         astInvert(sm);
         write_fixture(dir, "spec_invert_normalize", (AstMapping*)sm);
@@ -556,7 +556,7 @@ static void gen_specmap_fixtures(const char *dir) {
     /* specmap-02: partial cancellation */
     {
         double rf[] = {1.4e9, 0.0};
-        AstSpecMap *sm = astSpecMap(1, 0, "");
+        AstSpecMap *sm = astSpecMap(1, 0, " ");
         astSpecAdd(sm, "FRTOVL", 1, rf);
         astSpecAdd(sm, "VLTOFR", 1, rf);
         astSpecAdd(sm, "ENTOFR", 0, NULL);
@@ -566,7 +566,7 @@ static void gen_specmap_fixtures(const char *dir) {
 
     /* specmap-08: 0-arg unit conversion cancel */
     {
-        AstSpecMap *sm = astSpecMap(1, 0, "");
+        AstSpecMap *sm = astSpecMap(1, 0, " ");
         astSpecAdd(sm, "ENTOFR", 0, NULL);
         astSpecAdd(sm, "FRTOEN", 0, NULL);
         write_fixture(dir, "spec_unit_cancel", (AstMapping*)sm);
@@ -576,11 +576,11 @@ static void gen_specmap_fixtures(const char *dir) {
     /* specmap-03: multi-map merge without step reduction */
     {
         double rf[] = {1.4e9, 0.0};
-        AstSpecMap *s1 = astSpecMap(1, 0, "");
+        AstSpecMap *s1 = astSpecMap(1, 0, " ");
         astSpecAdd(s1, "FRTOVL", 1, rf);
-        AstSpecMap *s2 = astSpecMap(1, 0, "");
+        AstSpecMap *s2 = astSpecMap(1, 0, " ");
         astSpecAdd(s2, "ENTOFR", 0, NULL);
-        AstCmpMap *cm = astCmpMap(s1, s2, 1, "");
+        AstCmpMap *cm = astCmpMap(s1, s2, 1, " ");
         write_fixture(dir, "spec_merge_no_cancel", (AstMapping*)cm);
         cm = astAnnul(cm); s1 = astAnnul(s1); s2 = astAnnul(s2);
     }
@@ -588,7 +588,7 @@ static void gen_specmap_fixtures(const char *dir) {
     /* specmap-10: 2-arg local-standard cancel (szargs=3, pad to be safe) */
     {
         double args[] = {0.5, 1.2, 0.0, 0.0};
-        AstSpecMap *sm = astSpecMap(1, 0, "");
+        AstSpecMap *sm = astSpecMap(1, 0, " ");
         astSpecAdd(sm, "LKF2HL", 2, args);
         astSpecAdd(sm, "HLF2LK", 2, args);
         write_fixture(dir, "spec_lsr_cancel", (AstMapping*)sm);
@@ -598,7 +598,7 @@ static void gen_specmap_fixtures(const char *dir) {
     /* specmap-11: 3-arg geocentric cancel (szargs=4, pad) */
     {
         double args[] = {0.5, 1.2, 51544.0, 0.0, 0.0};
-        AstSpecMap *sm = astSpecMap(1, 0, "");
+        AstSpecMap *sm = astSpecMap(1, 0, " ");
         astSpecAdd(sm, "GEF2HL", 3, args);
         astSpecAdd(sm, "HLF2GE", 3, args);
         write_fixture(dir, "spec_geocentric_cancel", (AstMapping*)sm);
@@ -608,7 +608,7 @@ static void gen_specmap_fixtures(const char *dir) {
     /* specmap-12: 6-arg topocentric cancel (szargs=7, pad) */
     {
         double args[] = {-2.5, 0.9, 1000.0, 51544.0, 0.5, 1.2, 0.0};
-        AstSpecMap *sm = astSpecMap(1, 0, "");
+        AstSpecMap *sm = astSpecMap(1, 0, " ");
         astSpecAdd(sm, "TPF2HL", 6, args);
         astSpecAdd(sm, "HLF2TP", 6, args);
         write_fixture(dir, "spec_topocentric_cancel", (AstMapping*)sm);
@@ -624,7 +624,7 @@ static void gen_timemap_fixtures(const char *dir) {
     /* timemap-04: single inverted TimeMap normalizes (szargs=2, pad) */
     {
         double dut[] = {0.5, 0.0};
-        AstTimeMap *tm = astTimeMap(0, "");
+        AstTimeMap *tm = astTimeMap(0, " ");
         astTimeAdd(tm, "TAITOTT", 1, dut);
         astInvert(tm);
         write_fixture(dir, "time_invert_normalize", (AstMapping*)tm);
@@ -635,7 +635,7 @@ static void gen_timemap_fixtures(const char *dir) {
     {
         double dut[] = {0.5, 0.0};
         double dut2[] = {0.5, 0.0};
-        AstTimeMap *tm = astTimeMap(0, "");
+        AstTimeMap *tm = astTimeMap(0, " ");
         astTimeAdd(tm, "TAITOTT", 1, dut);
         astTimeAdd(tm, "TTTOTAI", 1, dut);
         astTimeAdd(tm, "TTTOTCG", 1, dut2);
@@ -647,11 +647,11 @@ static void gen_timemap_fixtures(const char *dir) {
     {
         double dut[] = {0.5, 0.0};
         double dut2[] = {0.3, 0.0};
-        AstTimeMap *t1 = astTimeMap(0, "");
+        AstTimeMap *t1 = astTimeMap(0, " ");
         astTimeAdd(t1, "TAITOTT", 1, dut);
-        AstTimeMap *t2 = astTimeMap(0, "");
+        AstTimeMap *t2 = astTimeMap(0, " ");
         astTimeAdd(t2, "TTTOTCG", 1, dut2);
-        AstCmpMap *cm = astCmpMap(t1, t2, 1, "");
+        AstCmpMap *cm = astCmpMap(t1, t2, 1, " ");
         write_fixture(dir, "time_merge_no_cancel", (AstMapping*)cm);
         cm = astAnnul(cm); t1 = astAnnul(t1); t2 = astAnnul(t2);
     }
@@ -659,7 +659,7 @@ static void gen_timemap_fixtures(const char *dir) {
     /* timemap-07: no-op MJDTOMJD step with zero offset (szargs=3, pad) */
     {
         double args[] = {0.0, 0.0, 0.0};
-        AstTimeMap *tm = astTimeMap(0, "");
+        AstTimeMap *tm = astTimeMap(0, " ");
         astTimeAdd(tm, "MJDTOMJD", 2, args);
         write_fixture(dir, "time_noop_eliminate", (AstMapping*)tm);
         tm = astAnnul(tm);
@@ -669,7 +669,7 @@ static void gen_timemap_fixtures(const char *dir) {
     {
         double args1[] = {0.0, 2400000.5, 0.0};
         double args2[] = {2400000.5, 0.0, 0.0};
-        AstTimeMap *tm = astTimeMap(0, "");
+        AstTimeMap *tm = astTimeMap(0, " ");
         astTimeAdd(tm, "MJDTOJD", 2, args1);
         astTimeAdd(tm, "JDTOMJD", 2, args2);
         write_fixture(dir, "time_2arg_swapped_cancel", (AstMapping*)tm);
@@ -679,7 +679,7 @@ static void gen_timemap_fixtures(const char *dir) {
     /* timemap-10: 2-arg same-order pair (TAITOUTC + UTCTOTAI) (szargs=3) */
     {
         double args[] = {53000.0, 0.5, 0.0};
-        AstTimeMap *tm = astTimeMap(0, "");
+        AstTimeMap *tm = astTimeMap(0, " ");
         astTimeAdd(tm, "TAITOUTC", 2, args);
         astTimeAdd(tm, "UTCTOTAI", 2, args);
         write_fixture(dir, "time_2arg_same_cancel", (AstMapping*)tm);
@@ -689,7 +689,7 @@ static void gen_timemap_fixtures(const char *dir) {
     /* timemap-11: 3-arg pair (GMSTTOLMST + LMSTTOGMST) (szargs=3, exact) */
     {
         double args[] = {-2.5, 1000.0, 1013.0, 0.0};
-        AstTimeMap *tm = astTimeMap(0, "");
+        AstTimeMap *tm = astTimeMap(0, " ");
         astTimeAdd(tm, "GMSTTOLMST", 3, args);
         astTimeAdd(tm, "LMSTTOGMST", 3, args);
         write_fixture(dir, "time_3arg_cancel", (AstMapping*)tm);
@@ -699,7 +699,7 @@ static void gen_timemap_fixtures(const char *dir) {
     /* timemap-12: 5-arg pair (TTTOTDB + TDBTOTT) (szargs=7, pad) */
     {
         double args[] = {53000.0, 0.5, -2.5, 6378.0, 0.0, 0.0, 0.0};
-        AstTimeMap *tm = astTimeMap(0, "");
+        AstTimeMap *tm = astTimeMap(0, " ");
         astTimeAdd(tm, "TTTOTDB", 5, args);
         astTimeAdd(tm, "TDBTOTT", 5, args);
         write_fixture(dir, "time_5arg_cancel", (AstMapping*)tm);
@@ -716,9 +716,9 @@ static void gen_permmap_fixtures(const char *dir) {
     {
         int inperm[] = {2, 1};
         int outperm[] = {2, 1};
-        AstPermMap *p1 = astPermMap(2, inperm, 2, outperm, NULL, "");
-        AstPermMap *p2 = astPermMap(2, inperm, 2, outperm, NULL, "");
-        AstCmpMap *cm = astCmpMap(p1, p2, 1, "");
+        AstPermMap *p1 = astPermMap(2, inperm, 2, outperm, NULL, " ");
+        AstPermMap *p2 = astPermMap(2, inperm, 2, outperm, NULL, " ");
+        AstCmpMap *cm = astCmpMap(p1, p2, 1, " ");
         write_fixture(dir, "perm_cancel_to_unit", (AstMapping*)cm);
         cm = astAnnul(cm); p1 = astAnnul(p1); p2 = astAnnul(p2);
     }
@@ -727,7 +727,7 @@ static void gen_permmap_fixtures(const char *dir) {
     {
         int inperm[] = {2, 1};
         int outperm[] = {2, 1};
-        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, NULL, "");
+        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, NULL, " ");
         astInvert(pm);
         write_fixture(dir, "perm_invert_normalize", (AstMapping*)pm);
         pm = astAnnul(pm);
@@ -741,19 +741,19 @@ static void gen_normmap_fixtures(const char *dir) {
 
     /* normmap-02: NormMap wrapping basic Frame → UnitMap */
     {
-        AstFrame *f = astFrame(2, "");
-        AstNormMap *nm = astNormMap(f, "");
+        AstFrame *f = astFrame(2, " ");
+        AstNormMap *nm = astNormMap(f, " ");
         write_fixture(dir, "normmap_basic_frame_to_unit", (AstMapping*)nm);
         nm = astAnnul(nm); f = astAnnul(f);
     }
 
     /* normmap-03: inverse NormMap pair cancels (SkyFrame) */
     {
-        AstSkyFrame *sf = astSkyFrame("");
-        AstNormMap *n1 = astNormMap(sf, "");
-        AstNormMap *n2 = astNormMap(sf, "");
+        AstSkyFrame *sf = astSkyFrame(" ");
+        AstNormMap *n1 = astNormMap(sf, " ");
+        AstNormMap *n2 = astNormMap(sf, " ");
         astInvert(n1);
-        AstCmpMap *cm = astCmpMap(n1, n2, 1, "");
+        AstCmpMap *cm = astCmpMap(n1, n2, 1, " ");
         write_fixture(dir, "normmap_inverse_cancel", (AstMapping*)cm);
         cm = astAnnul(cm); n1 = astAnnul(n1); n2 = astAnnul(n2);
         sf = astAnnul(sf);
@@ -761,10 +761,10 @@ static void gen_normmap_fixtures(const char *dir) {
 
     /* normmap-05: duplicate NormMaps (same direction) → extras become UnitMap */
     {
-        AstSkyFrame *sf = astSkyFrame("");
-        AstNormMap *n1 = astNormMap(sf, "");
-        AstNormMap *n2 = astNormMap(sf, "");
-        AstCmpMap *cm = astCmpMap(n1, n2, 1, "");
+        AstSkyFrame *sf = astSkyFrame(" ");
+        AstNormMap *n1 = astNormMap(sf, " ");
+        AstNormMap *n2 = astNormMap(sf, " ");
+        AstCmpMap *cm = astCmpMap(n1, n2, 1, " ");
         write_fixture(dir, "normmap_duplicate_elim", (AstMapping*)cm);
         cm = astAnnul(cm); n1 = astAnnul(n1); n2 = astAnnul(n2);
         sf = astAnnul(sf);
@@ -780,9 +780,9 @@ static void gen_unitnormmap_fixtures(const char *dir) {
     {
         double centre[] = {1.0, 2.0};
         double shifts[] = {0.5, 0.5};
-        AstUnitNormMap *unm = astUnitNormMap(2, centre, "");
-        AstShiftMap *sm = astShiftMap(2, shifts, "");
-        AstCmpMap *cm = astCmpMap(sm, unm, 1, "");
+        AstUnitNormMap *unm = astUnitNormMap(2, centre, " ");
+        AstShiftMap *sm = astShiftMap(2, shifts, " ");
+        AstCmpMap *cm = astCmpMap(sm, unm, 1, " ");
         write_fixture(dir, "unitnormmap_shift_fwd_merge", (AstMapping*)cm);
         cm = astAnnul(cm); sm = astAnnul(sm); unm = astAnnul(unm);
     }
@@ -791,10 +791,10 @@ static void gen_unitnormmap_fixtures(const char *dir) {
     {
         double centre[] = {1.0, 2.0};
         double shifts[] = {0.5, 0.5};
-        AstUnitNormMap *unm = astUnitNormMap(2, centre, "");
+        AstUnitNormMap *unm = astUnitNormMap(2, centre, " ");
         astInvert(unm);
-        AstShiftMap *sm = astShiftMap(2, shifts, "");
-        AstCmpMap *cm = astCmpMap(unm, sm, 1, "");
+        AstShiftMap *sm = astShiftMap(2, shifts, " ");
+        AstCmpMap *cm = astCmpMap(unm, sm, 1, " ");
         write_fixture(dir, "unitnormmap_inv_shift_merge", (AstMapping*)cm);
         cm = astAnnul(cm); sm = astAnnul(sm); unm = astAnnul(unm);
     }
@@ -802,10 +802,10 @@ static void gen_unitnormmap_fixtures(const char *dir) {
     /* unitnormmap-07: fwd + inv with same centre → UnitMap */
     {
         double centre[] = {1.0, 2.0};
-        AstUnitNormMap *u1 = astUnitNormMap(2, centre, "");
-        AstUnitNormMap *u2 = astUnitNormMap(2, centre, "");
+        AstUnitNormMap *u1 = astUnitNormMap(2, centre, " ");
+        AstUnitNormMap *u2 = astUnitNormMap(2, centre, " ");
         astInvert(u2);
-        AstCmpMap *cm = astCmpMap(u1, u2, 1, "");
+        AstCmpMap *cm = astCmpMap(u1, u2, 1, " ");
         write_fixture(dir, "unitnormmap_inverse_cancel", (AstMapping*)cm);
         cm = astAnnul(cm); u1 = astAnnul(u1); u2 = astAnnul(u2);
     }
@@ -813,10 +813,10 @@ static void gen_unitnormmap_fixtures(const char *dir) {
     /* unitnormmap-08: inv + fwd with same centre → UnitMap */
     {
         double centre[] = {1.0, 2.0};
-        AstUnitNormMap *u1 = astUnitNormMap(2, centre, "");
-        AstUnitNormMap *u2 = astUnitNormMap(2, centre, "");
+        AstUnitNormMap *u1 = astUnitNormMap(2, centre, " ");
+        AstUnitNormMap *u2 = astUnitNormMap(2, centre, " ");
         astInvert(u1);
-        AstCmpMap *cm = astCmpMap(u1, u2, 1, "");
+        AstCmpMap *cm = astCmpMap(u1, u2, 1, " ");
         write_fixture(dir, "unitnormmap_inv_fwd_cancel", (AstMapping*)cm);
         cm = astAnnul(cm); u1 = astAnnul(u1); u2 = astAnnul(u2);
     }
@@ -825,10 +825,10 @@ static void gen_unitnormmap_fixtures(const char *dir) {
     {
         double c1[] = {1.0, 2.0};
         double c2[] = {3.0, 4.0};
-        AstUnitNormMap *u1 = astUnitNormMap(2, c1, "");
-        AstUnitNormMap *u2 = astUnitNormMap(2, c2, "");
+        AstUnitNormMap *u1 = astUnitNormMap(2, c1, " ");
+        AstUnitNormMap *u2 = astUnitNormMap(2, c2, " ");
         astInvert(u2);
-        AstCmpMap *cm = astCmpMap(u1, u2, 1, "");
+        AstCmpMap *cm = astCmpMap(u1, u2, 1, " ");
         write_fixture(dir, "unitnormmap_diff_centre_to_shift", (AstMapping*)cm);
         cm = astAnnul(cm); u1 = astAnnul(u1); u2 = astAnnul(u2);
     }
@@ -846,10 +846,10 @@ static void gen_grismmap_fixtures(const char *dir) {
 
     /* grismmap-03: ZoomMap + inverted GrismMap → absorbed */
     {
-        AstGrismMap *gm = astGrismMap("");
+        AstGrismMap *gm = astGrismMap(" ");
         astInvert(gm);
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstCmpMap *cm = astCmpMap(zm, gm, 1, "");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(zm, gm, 1, " ");
         write_fixture(dir, "grism_zoom_inv_merge", (AstMapping*)cm);
         cm = astAnnul(cm); gm = astAnnul(gm); zm = astAnnul(zm);
     }
@@ -857,8 +857,8 @@ static void gen_grismmap_fixtures(const char *dir) {
     /* grismmap-01: forward GrismMap + ZoomMap → merge into a single GrismMap */
     {
         AstGrismMap *gm = astGrismMap(GRISM_PARAMS);
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstCmpMap *cm = astCmpMap(gm, zm, 1, "");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(gm, zm, 1, " ");
         write_fixture(dir, "grism_zoom_merge", (AstMapping*)cm);
         cm = astAnnul(cm); gm = astAnnul(gm); zm = astAnnul(zm);
     }
@@ -871,7 +871,7 @@ static void gen_grismmap_fixtures(const char *dir) {
             "GrismAlpha=0.1,GrismG=2e-4,GrismM=-1,"
             "GrismEps=0.02,GrismTheta=0.03");
         astInvert(g2);
-        AstCmpMap *cm = astCmpMap(g1, g2, 1, "");
+        AstCmpMap *cm = astCmpMap(g1, g2, 1, " ");
         write_fixture(dir, "grism_inverse_cancel", (AstMapping*)cm);
         cm = astAnnul(cm); g1 = astAnnul(g1); g2 = astAnnul(g2);
     }
@@ -884,7 +884,7 @@ static void gen_wcsmap_fixtures(const char *dir) {
 
     /* wcsmap-01: AST__WCSBAD → UnitMap */
     {
-        AstWcsMap *wm = astWcsMap(2, AST__WCSBAD, 1, 2, "");
+        AstWcsMap *wm = astWcsMap(2, AST__WCSBAD, 1, 2, " ");
         write_fixture(dir, "wcsmap_bad_to_unit", (AstMapping*)wm);
         wm = astAnnul(wm);
     }
@@ -893,12 +893,12 @@ static void gen_wcsmap_fixtures(const char *dir) {
     {
         int inperm[] = {2, 1};
         int outperm[] = {2, 1};
-        AstWcsMap *w1 = astWcsMap(2, AST__TAN, 1, 2, "");
-        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, NULL, "");
-        AstWcsMap *w2 = astWcsMap(2, AST__TAN, 2, 1, "");
+        AstWcsMap *w1 = astWcsMap(2, AST__TAN, 1, 2, " ");
+        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, NULL, " ");
+        AstWcsMap *w2 = astWcsMap(2, AST__TAN, 2, 1, " ");
         astInvert(w2);
-        AstCmpMap *inner = astCmpMap(pm, w2, 1, "");
-        AstCmpMap *outer = astCmpMap(w1, inner, 1, "");
+        AstCmpMap *inner = astCmpMap(pm, w2, 1, " ");
+        AstCmpMap *outer = astCmpMap(w1, inner, 1, " ");
         write_fixture(dir, "wcsmap_perm_swap_cancel", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         w1 = astAnnul(w1); pm = astAnnul(pm); w2 = astAnnul(w2);
@@ -915,7 +915,7 @@ static void gen_sphmap_fixtures(const char *dir) {
         AstSphMap *s1 = astSphMap("UnitRadius=1");
         AstSphMap *s2 = astSphMap("UnitRadius=1");
         astInvert(s2);
-        AstCmpMap *cm = astCmpMap(s1, s2, 1, "");
+        AstCmpMap *cm = astCmpMap(s1, s2, 1, " ");
         write_fixture(dir, "sph_fwd_inv_unitradius_cancel", (AstMapping*)cm);
         cm = astAnnul(cm); s1 = astAnnul(s1); s2 = astAnnul(s2);
     }
@@ -924,10 +924,10 @@ static void gen_sphmap_fixtures(const char *dir) {
     {
         AstSphMap *s1 = astSphMap("UnitRadius=1");
         astInvert(s1);
-        AstZoomMap *zm = astZoomMap(3, -1.0, "");
+        AstZoomMap *zm = astZoomMap(3, -1.0, " ");
         AstSphMap *s2 = astSphMap("UnitRadius=1");
-        AstCmpMap *inner = astCmpMap(zm, s2, 1, "");
-        AstCmpMap *outer = astCmpMap(s1, inner, 1, "");
+        AstCmpMap *inner = astCmpMap(zm, s2, 1, " ");
+        AstCmpMap *outer = astCmpMap(s1, inner, 1, " ");
         write_fixture(dir, "sph_zoom_sandwich", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         s1 = astAnnul(s1); zm = astAnnul(zm); s2 = astAnnul(s2);
@@ -941,10 +941,10 @@ static void gen_sphmap_fixtures(const char *dir) {
         AstSphMap *s1 = astSphMap("PolarLong=0");
         astInvert(s1);
         double diag[] = {2.0, -2.0, 2.0};
-        AstMatrixMap *mm = astMatrixMap(3, 3, 1, diag, "");
+        AstMatrixMap *mm = astMatrixMap(3, 3, 1, diag, " ");
         AstSphMap *s2 = astSphMap("PolarLong=0");
-        AstCmpMap *inner = astCmpMap(mm, s2, 1, "");
-        AstCmpMap *outer = astCmpMap(s1, inner, 1, "");
+        AstCmpMap *inner = astCmpMap(mm, s2, 1, " ");
+        AstCmpMap *outer = astCmpMap(s1, inner, 1, " ");
         write_fixture(dir, "sph_matrix_sandwich", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         s1 = astAnnul(s1); mm = astAnnul(mm); s2 = astAnnul(s2);
@@ -959,9 +959,9 @@ static void gen_pcdmap_fixtures(const char *dir) {
     /* pcdmap-03: PcdMap + UnitMap → UnitMap eliminated */
     {
         double pcdcen[] = {100.0, 100.0};
-        AstPcdMap *pm = astPcdMap(0.001, pcdcen, "");
-        AstUnitMap *um = astUnitMap(2, "");
-        AstCmpMap *cm = astCmpMap(pm, um, 1, "");
+        AstPcdMap *pm = astPcdMap(0.001, pcdcen, " ");
+        AstUnitMap *um = astUnitMap(2, " ");
+        AstCmpMap *cm = astCmpMap(pm, um, 1, " ");
         write_fixture(dir, "pcd_unit_series_merge", (AstMapping*)cm);
         cm = astAnnul(cm); pm = astAnnul(pm); um = astAnnul(um);
     }
@@ -969,12 +969,12 @@ static void gen_pcdmap_fixtures(const char *dir) {
     /* pcdmap-04: PcdMap swaps with ZoomMap to reach inverse PcdMap */
     {
         double pcdcen[] = {0.0, 0.0};
-        AstPcdMap *p1 = astPcdMap(0.001, pcdcen, "");
-        AstZoomMap *zm = astZoomMap(2, 1.0, "");
-        AstPcdMap *p2 = astPcdMap(0.001, pcdcen, "");
+        AstPcdMap *p1 = astPcdMap(0.001, pcdcen, " ");
+        AstZoomMap *zm = astZoomMap(2, 1.0, " ");
+        AstPcdMap *p2 = astPcdMap(0.001, pcdcen, " ");
         astInvert(p2);
-        AstCmpMap *inner = astCmpMap(zm, p2, 1, "");
-        AstCmpMap *outer = astCmpMap(p1, inner, 1, "");
+        AstCmpMap *inner = astCmpMap(zm, p2, 1, " ");
+        AstCmpMap *outer = astCmpMap(p1, inner, 1, " ");
         write_fixture(dir, "pcd_zoom_swap_cancel", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         p1 = astAnnul(p1); zm = astAnnul(zm); p2 = astAnnul(p2);
@@ -1019,11 +1019,11 @@ static void gen_chebymap_fixtures(const char *dir) {
         double lbnd[] = {-1.0};
         double ubnd[] = { 1.0};
         AstChebyMap *c1 = astChebyMap(1, 1, 1, coeff_f, 1, coeff_i,
-                                      lbnd, ubnd, lbnd, ubnd, "");
+                                      lbnd, ubnd, lbnd, ubnd, " ");
         AstChebyMap *c2 = astChebyMap(1, 1, 1, coeff_f, 1, coeff_i,
-                                      lbnd, ubnd, lbnd, ubnd, "");
+                                      lbnd, ubnd, lbnd, ubnd, " ");
         astInvert(c2);
-        AstCmpMap *cm = astCmpMap(c1, c2, 1, "");
+        AstCmpMap *cm = astCmpMap(c1, c2, 1, " ");
         write_fixture(dir, "chebymap_inverse_cancel", (AstMapping*)cm);
         cm = astAnnul(cm); c1 = astAnnul(c1); c2 = astAnnul(c2);
     }
@@ -1047,7 +1047,7 @@ static void gen_chebymap_fixtures(const char *dir) {
         double lbnd[] = {-2.0, -2.0};
         double ubnd[] = { 2.0,  2.0};
         AstChebyMap *cm = astChebyMap(2, 2, 6, coeff_f, 0, NULL,
-                                       lbnd, ubnd, NULL, NULL, "");
+                                       lbnd, ubnd, NULL, NULL, " ");
         write_negative_fixture(dir, "neg_chebymap_standalone",
                                 (AstMapping*)cm);
         cm = astAnnul(cm);
@@ -1061,11 +1061,11 @@ static void gen_switchmap_fixtures(const char *dir) {
 
     /* switchmap-03: inverted SwitchMap normalizes */
     {
-        AstZoomMap *fsel = astZoomMap(1, 1.0, "");
-        AstZoomMap *isel = astZoomMap(1, 1.0, "");
-        AstZoomMap *r1 = astZoomMap(1, 2.0, "");
+        AstZoomMap *fsel = astZoomMap(1, 1.0, " ");
+        AstZoomMap *isel = astZoomMap(1, 1.0, " ");
+        AstZoomMap *r1 = astZoomMap(1, 2.0, " ");
         AstMapping *routes[] = {(AstMapping*)r1};
-        AstSwitchMap *sw = astSwitchMap(fsel, isel, 1, (void**)routes, "");
+        AstSwitchMap *sw = astSwitchMap(fsel, isel, 1, (void**)routes, " ");
         astInvert(sw);
         write_fixture(dir, "switchmap_invert_normalize", (AstMapping*)sw);
         sw = astAnnul(sw); fsel = astAnnul(fsel); isel = astAnnul(isel);
@@ -1074,13 +1074,13 @@ static void gen_switchmap_fixtures(const char *dir) {
 
     /* switchmap-04: SwitchMap internal simplification */
     {
-        AstZoomMap *fsel = astZoomMap(1, 1.0, "");
-        AstZoomMap *isel = astZoomMap(1, 1.0, "");
-        AstZoomMap *za = astZoomMap(1, 2.0, "");
-        AstZoomMap *zb = astZoomMap(1, 3.0, "");
-        AstCmpMap *route = astCmpMap(za, zb, 1, "");
+        AstZoomMap *fsel = astZoomMap(1, 1.0, " ");
+        AstZoomMap *isel = astZoomMap(1, 1.0, " ");
+        AstZoomMap *za = astZoomMap(1, 2.0, " ");
+        AstZoomMap *zb = astZoomMap(1, 3.0, " ");
+        AstCmpMap *route = astCmpMap(za, zb, 1, " ");
         AstMapping *routes[] = {(AstMapping*)route};
-        AstSwitchMap *sw = astSwitchMap(fsel, isel, 1, (void**)routes, "");
+        AstSwitchMap *sw = astSwitchMap(fsel, isel, 1, (void**)routes, " ");
         write_fixture(dir, "switchmap_internal_simplify", (AstMapping*)sw);
         sw = astAnnul(sw); fsel = astAnnul(fsel); isel = astAnnul(isel);
         za = astAnnul(za); zb = astAnnul(zb); route = astAnnul(route);
@@ -1094,13 +1094,13 @@ static void gen_tranmap_extra_fixtures(const char *dir) {
 
     /* tranmap-04: adjacent TranMap merge in series */
     {
-        AstZoomMap *z2 = astZoomMap(1, 2.0, "");
-        AstZoomMap *z05 = astZoomMap(1, 0.5, "");
-        AstZoomMap *z3 = astZoomMap(1, 3.0, "");
-        AstZoomMap *z033 = astZoomMap(1, 1.0/3.0, "");
-        AstTranMap *t1 = astTranMap(z2, z05, "");
-        AstTranMap *t2 = astTranMap(z3, z033, "");
-        AstCmpMap *cm = astCmpMap(t1, t2, 1, "");
+        AstZoomMap *z2 = astZoomMap(1, 2.0, " ");
+        AstZoomMap *z05 = astZoomMap(1, 0.5, " ");
+        AstZoomMap *z3 = astZoomMap(1, 3.0, " ");
+        AstZoomMap *z033 = astZoomMap(1, 1.0/3.0, " ");
+        AstTranMap *t1 = astTranMap(z2, z05, " ");
+        AstTranMap *t2 = astTranMap(z3, z033, " ");
+        AstCmpMap *cm = astCmpMap(t1, t2, 1, " ");
         write_fixture(dir, "tranmap_adjacent_merge", (AstMapping*)cm);
         cm = astAnnul(cm); t1 = astAnnul(t1); t2 = astAnnul(t2);
         z2 = astAnnul(z2); z05 = astAnnul(z05);
@@ -1118,11 +1118,11 @@ static void gen_matrix_cascade_fixtures(const char *dir) {
         double diag1[] = {2.0, 3.0};
         double ina[] = {0, 0}, inb[] = {1, 1}, outa[] = {1, 2}, outb[] = {5, 8};
         double diag2[] = {4.0, 5.0};
-        AstMatrixMap *m1 = astMatrixMap(2, 2, 1, diag1, "");
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstMatrixMap *m2 = astMatrixMap(2, 2, 1, diag2, "");
-        AstCmpMap *inner = astCmpMap(wm, m2, 1, "");
-        AstCmpMap *outer = astCmpMap(m1, inner, 1, "");
+        AstMatrixMap *m1 = astMatrixMap(2, 2, 1, diag1, " ");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstMatrixMap *m2 = astMatrixMap(2, 2, 1, diag2, " ");
+        AstCmpMap *inner = astCmpMap(wm, m2, 1, " ");
+        AstCmpMap *outer = astCmpMap(m1, inner, 1, " ");
         write_fixture(dir, "matrix_swap_past_win", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         m1 = astAnnul(m1); wm = astAnnul(wm); m2 = astAnnul(m2);
@@ -1135,11 +1135,11 @@ static void gen_matrix_cascade_fixtures(const char *dir) {
        — a class change that triggers the swap acceptance. */
     {
         double mat[] = {1.0, 0.0, 1.0, 1.0};
-        AstMatrixMap *mm = astMatrixMap(2, 2, 0, mat, "");
+        AstMatrixMap *mm = astMatrixMap(2, 2, 0, mat, " ");
         double ina[] = {0, 0}, inb[] = {1, 1};
         double outa[] = {1, 2}, outb[] = {4, 6};
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstCmpMap *cm = astCmpMap(mm, wm, 1, "");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstCmpMap *cm = astCmpMap(mm, wm, 1, " ");
         write_fixture(dir, "matrix_swap_win_simplifies", (AstMapping*)cm);
         cm = astAnnul(cm); mm = astAnnul(mm); wm = astAnnul(wm);
     }
@@ -1150,11 +1150,11 @@ static void gen_matrix_cascade_fixtures(const char *dir) {
         int inperm[] = {2, 1};
         int outperm[] = {2, 1};
         double diag2[] = {4.0, 5.0};
-        AstMatrixMap *m1 = astMatrixMap(2, 2, 1, diag1, "");
-        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, NULL, "");
-        AstMatrixMap *m2 = astMatrixMap(2, 2, 1, diag2, "");
-        AstCmpMap *inner = astCmpMap(pm, m2, 1, "");
-        AstCmpMap *outer = astCmpMap(m1, inner, 1, "");
+        AstMatrixMap *m1 = astMatrixMap(2, 2, 1, diag1, " ");
+        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, NULL, " ");
+        AstMatrixMap *m2 = astMatrixMap(2, 2, 1, diag2, " ");
+        AstCmpMap *inner = astCmpMap(pm, m2, 1, " ");
+        AstCmpMap *outer = astCmpMap(m1, inner, 1, " ");
         write_fixture(dir, "matrix_swap_past_perm", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         m1 = astAnnul(m1); pm = astAnnul(pm); m2 = astAnnul(m2);
@@ -1169,7 +1169,7 @@ static void gen_slamap_extra_fixtures(const char *dir) {
     /* slamap-14: 1-arg helio-ecliptic (EQHE+HEEQ) */
     {
         double args[] = {51544.0};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "EQHE", 1, args);
         astSlaAdd(sm, "HEEQ", 1, args);
         write_fixture(dir, "sla_helioecl_cancel", (AstMapping*)sm);
@@ -1179,7 +1179,7 @@ static void gen_slamap_extra_fixtures(const char *dir) {
     /* slamap-15: 1-arg HA (R2H+H2R) */
     {
         double args[] = {3.5};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "R2H", 1, args);
         astSlaAdd(sm, "H2R", 1, args);
         write_fixture(dir, "sla_ha_cancel", (AstMapping*)sm);
@@ -1189,7 +1189,7 @@ static void gen_slamap_extra_fixtures(const char *dir) {
     /* slamap-17: 2-arg AzEl (H2E+E2H) */
     {
         double args[] = {0.9, 0.001};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "H2E", 2, args);
         astSlaAdd(sm, "E2H", 2, args);
         write_fixture(dir, "sla_azel_cancel", (AstMapping*)sm);
@@ -1204,14 +1204,14 @@ static void gen_switchmap_extra_fixtures(const char *dir) {
 
     /* switchmap-01: SwitchMap + Inverse(SwitchMap) cancel to UnitMap */
     {
-        AstZoomMap *fsel = astZoomMap(1, 1.0, "");
-        AstZoomMap *isel = astZoomMap(1, 1.0, "");
-        AstZoomMap *r1 = astZoomMap(1, 2.0, "");
+        AstZoomMap *fsel = astZoomMap(1, 1.0, " ");
+        AstZoomMap *isel = astZoomMap(1, 1.0, " ");
+        AstZoomMap *r1 = astZoomMap(1, 2.0, " ");
         AstMapping *routes[] = {(AstMapping*)r1};
-        AstSwitchMap *s1 = astSwitchMap(fsel, isel, 1, (void**)routes, "");
-        AstSwitchMap *s2 = astSwitchMap(fsel, isel, 1, (void**)routes, "");
+        AstSwitchMap *s1 = astSwitchMap(fsel, isel, 1, (void**)routes, " ");
+        AstSwitchMap *s2 = astSwitchMap(fsel, isel, 1, (void**)routes, " ");
         astInvert(s2);
-        AstCmpMap *cm = astCmpMap(s1, s2, 1, "");
+        AstCmpMap *cm = astCmpMap(s1, s2, 1, " ");
         write_fixture(dir, "switchmap_inverse_cancel", (AstMapping*)cm);
         cm = astAnnul(cm); s1 = astAnnul(s1); s2 = astAnnul(s2);
         fsel = astAnnul(fsel); isel = astAnnul(isel); r1 = astAnnul(r1);
@@ -1227,9 +1227,9 @@ static void gen_pcdmap_extra_fixtures(const char *dir) {
        ZoomMap(1) simplifies to UnitMap after the swap. */
     {
         double pcdcen[] = {0.0, 0.0};
-        AstPcdMap *pm = astPcdMap(0.001, pcdcen, "");
-        AstZoomMap *zm = astZoomMap(2, 1.0, "");
-        AstCmpMap *cm = astCmpMap(pm, zm, 1, "");
+        AstPcdMap *pm = astPcdMap(0.001, pcdcen, " ");
+        AstZoomMap *zm = astZoomMap(2, 1.0, " ");
+        AstCmpMap *cm = astCmpMap(pm, zm, 1, " ");
         write_fixture(dir, "pcd_swap_zoom_simplifies", (AstMapping*)cm);
         cm = astAnnul(cm); pm = astAnnul(pm); zm = astAnnul(zm);
     }
@@ -1239,12 +1239,12 @@ static void gen_pcdmap_extra_fixtures(const char *dir) {
         double pcdcen[] = {0.0, 0.0};
         int inperm[] = {2, 1};
         int outperm[] = {2, 1};
-        AstPcdMap *p1 = astPcdMap(0.001, pcdcen, "");
-        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, NULL, "");
-        AstPcdMap *p2 = astPcdMap(0.001, pcdcen, "");
+        AstPcdMap *p1 = astPcdMap(0.001, pcdcen, " ");
+        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, NULL, " ");
+        AstPcdMap *p2 = astPcdMap(0.001, pcdcen, " ");
         astInvert(p2);
-        AstCmpMap *inner = astCmpMap(pm, p2, 1, "");
-        AstCmpMap *outer = astCmpMap(p1, inner, 1, "");
+        AstCmpMap *inner = astCmpMap(pm, p2, 1, " ");
+        AstCmpMap *outer = astCmpMap(p1, inner, 1, " ");
         write_fixture(dir, "pcd_perm_swap_cancel", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         p1 = astAnnul(p1); pm = astAnnul(pm); p2 = astAnnul(p2);
@@ -1264,11 +1264,11 @@ static void gen_win_extra_cascade_fixtures(const char *dir) {
         int inperm[] = {1, 2};
         int outperm[] = {1, 2, -1};
         double consts[] = {5.0};
-        AstPermMap *pm = astPermMap(2, inperm, 3, outperm, consts, "");
+        AstPermMap *pm = astPermMap(2, inperm, 3, outperm, consts, " ");
         double ina[] = {0, 0, 0}, inb[] = {1, 1, 1};
         double outa[] = {0, 0, 5}, outb[] = {1, 1, 8};
-        AstWinMap *wm = astWinMap(3, ina, inb, outa, outb, "");
-        AstCmpMap *cm = astCmpMap(pm, wm, 1, "");
+        AstWinMap *wm = astWinMap(3, ina, inb, outa, outb, " ");
+        AstCmpMap *cm = astCmpMap(pm, wm, 1, " ");
         write_fixture(dir, "win_swap_simplifies", (AstMapping*)cm);
         cm = astAnnul(cm); pm = astAnnul(pm); wm = astAnnul(wm);
     }
@@ -1282,11 +1282,11 @@ static void gen_win_extra_cascade_fixtures(const char *dir) {
         int outperm[] = {2, 1};
         double ina[] = {0, 0}, inb[] = {1, 1};
         double outa[] = {1, 2}, outb[] = {4, 6};
-        AstPermMap *p1 = astPermMap(2, inperm, 2, outperm, NULL, "");
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstPermMap *p2 = astPermMap(2, inperm, 2, outperm, NULL, "");
-        AstCmpMap *inner = astCmpMap(wm, p2, 1, "");
-        AstCmpMap *outer = astCmpMap(p1, inner, 1, "");
+        AstPermMap *p1 = astPermMap(2, inperm, 2, outperm, NULL, " ");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstPermMap *p2 = astPermMap(2, inperm, 2, outperm, NULL, " ");
+        AstCmpMap *inner = astCmpMap(wm, p2, 1, " ");
+        AstCmpMap *outer = astCmpMap(p1, inner, 1, " ");
         write_fixture(dir, "win_swap_outer_merge", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         p1 = astAnnul(p1); wm = astAnnul(wm); p2 = astAnnul(p2);
@@ -1297,12 +1297,12 @@ static void gen_win_extra_cascade_fixtures(const char *dir) {
         double ina[] = {0, 0}, inb[] = {1, 1};
         double outa[] = {1, 2}, outb[] = {3, 5};
         double shifts[] = {1.0};
-        AstShiftMap *sm1 = astShiftMap(1, shifts, "");
+        AstShiftMap *sm1 = astShiftMap(1, shifts, " ");
         double shifts2[] = {2.0};
-        AstShiftMap *sm2 = astShiftMap(1, shifts2, "");
-        AstCmpMap *par = astCmpMap(sm1, sm2, 0, "");
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstCmpMap *cm = astCmpMap(par, wm, 1, "");
+        AstShiftMap *sm2 = astShiftMap(1, shifts2, " ");
+        AstCmpMap *par = astCmpMap(sm1, sm2, 0, " ");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstCmpMap *cm = astCmpMap(par, wm, 1, " ");
         write_fixture(dir, "win_cmpmap_parallel_merge", (AstMapping*)cm);
         cm = astAnnul(cm); par = astAnnul(par); wm = astAnnul(wm);
         sm1 = astAnnul(sm1); sm2 = astAnnul(sm2);
@@ -1317,7 +1317,7 @@ static void gen_slamap_4arg_fixtures(const char *dir) {
     /* slamap-18: 4-arg HPC (HPCEQ+EQHPC) */
     {
         double args[] = {51544.0, 0.5, 1.2, 150.0e6};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "HPCEQ", 4, args);
         astSlaAdd(sm, "EQHPC", 4, args);
         write_fixture(dir, "sla_hpc_cancel", (AstMapping*)sm);
@@ -1327,7 +1327,7 @@ static void gen_slamap_4arg_fixtures(const char *dir) {
     /* slamap-19: 4-arg HPR (HPREQ+EQHPR) */
     {
         double args[] = {51544.0, 0.5, 1.2, 150.0e6};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "HPREQ", 4, args);
         astSlaAdd(sm, "EQHPR", 4, args);
         write_fixture(dir, "sla_hpr_cancel", (AstMapping*)sm);
@@ -1346,11 +1346,11 @@ static void gen_win_cascade_fixtures(const char *dir) {
         double outa1[] = {1, 2}, outb1[] = {3, 4};
         double outa2[] = {5, 6}, outb2[] = {7, 8};
         double diag[] = {2.0, 3.0};
-        AstWinMap *w1 = astWinMap(2, ina, inb, outa1, outb1, "");
-        AstMatrixMap *mm = astMatrixMap(2, 2, 1, diag, "");
-        AstWinMap *w2 = astWinMap(2, ina, inb, outa2, outb2, "");
-        AstCmpMap *inner = astCmpMap(mm, w2, 1, "");
-        AstCmpMap *outer = astCmpMap(w1, inner, 1, "");
+        AstWinMap *w1 = astWinMap(2, ina, inb, outa1, outb1, " ");
+        AstMatrixMap *mm = astMatrixMap(2, 2, 1, diag, " ");
+        AstWinMap *w2 = astWinMap(2, ina, inb, outa2, outb2, " ");
+        AstCmpMap *inner = astCmpMap(mm, w2, 1, " ");
+        AstCmpMap *outer = astCmpMap(w1, inner, 1, " ");
         write_fixture(dir, "win_swap_past_matrix", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         w1 = astAnnul(w1); mm = astAnnul(mm); w2 = astAnnul(w2);
@@ -1361,11 +1361,11 @@ static void gen_win_cascade_fixtures(const char *dir) {
         double ina[] = {0, 0}, inb[] = {1, 1};
         double outa1[] = {0, 0}, outb1[] = {1, 1};
         double outa2[] = {0, 0}, outb2[] = {1, 1};
-        AstWinMap *w1 = astWinMap(2, ina, inb, outa1, outb1, "");
-        AstWcsMap *wcs = astWcsMap(2, AST__TAN, 1, 2, "");
-        AstWinMap *w2 = astWinMap(2, ina, inb, outa2, outb2, "");
-        AstCmpMap *inner = astCmpMap(wcs, w2, 1, "");
-        AstCmpMap *outer = astCmpMap(w1, inner, 1, "");
+        AstWinMap *w1 = astWinMap(2, ina, inb, outa1, outb1, " ");
+        AstWcsMap *wcs = astWcsMap(2, AST__TAN, 1, 2, " ");
+        AstWinMap *w2 = astWinMap(2, ina, inb, outa2, outb2, " ");
+        AstCmpMap *inner = astCmpMap(wcs, w2, 1, " ");
+        AstCmpMap *outer = astCmpMap(w1, inner, 1, " ");
         write_fixture(dir, "win_swap_past_wcsmap", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         w1 = astAnnul(w1); wcs = astAnnul(wcs); w2 = astAnnul(w2);
@@ -1379,15 +1379,15 @@ static void gen_selectormap_fixtures(const char *dir) {
 
     /* selectormap-05: SelectorMap + Inverse(SelectorMap) cancel to UnitMap */
     {
-        AstFrame *f = astFrame(2, "");
+        AstFrame *f = astFrame(2, " ");
         double lbnd[] = {0.0, 0.0};
         double ubnd[] = {10.0, 10.0};
-        AstBox *box = astBox(f, 1, lbnd, ubnd, NULL, "");
+        AstBox *box = astBox(f, 1, lbnd, ubnd, NULL, " ");
         AstMapping *regs[] = {(AstMapping*)box};
-        AstSelectorMap *s1 = astSelectorMap(1, (void**)regs, AST__BAD, "");
-        AstSelectorMap *s2 = astSelectorMap(1, (void**)regs, AST__BAD, "");
+        AstSelectorMap *s1 = astSelectorMap(1, (void**)regs, AST__BAD, " ");
+        AstSelectorMap *s2 = astSelectorMap(1, (void**)regs, AST__BAD, " ");
         astInvert(s2);
-        AstCmpMap *cm = astCmpMap(s1, s2, 1, "");
+        AstCmpMap *cm = astCmpMap(s1, s2, 1, " ");
         write_fixture(dir, "selectormap_inverse_cancel", (AstMapping*)cm);
         cm = astAnnul(cm); s1 = astAnnul(s1); s2 = astAnnul(s2);
         box = astAnnul(box); f = astAnnul(f);
@@ -1420,8 +1420,8 @@ static void gen_dssmap_fixtures(const char *dir) {
                 /* Use unsimplified map — it should contain a DssMap. */
                 double ina[] = {0, 0}, inb[] = {1, 1};
                 double outa[] = {1, 1}, outb[] = {2, 2};
-                AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-                AstCmpMap *cm = astCmpMap(wm, map, 1, "");
+                AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+                AstCmpMap *cm = astCmpMap(wm, map, 1, " ");
                 write_fixture(dir, "dss_winmap_absorb", (AstMapping*)cm);
                 cm = astAnnul(cm); wm = astAnnul(wm);
                 map = astAnnul(map);
@@ -1465,7 +1465,7 @@ static void gen_negative_fixtures(const char *dir) {
     /* matrixmap-04: diagonal MatrixMap with unequal elements — can't become ZoomMap */
     {
         double diag[] = {2.0, 3.0};
-        AstMatrixMap *mm = astMatrixMap(2, 2, 1, diag, "");
+        AstMatrixMap *mm = astMatrixMap(2, 2, 1, diag, " ");
         write_negative_fixture(dir, "neg_matrix_diag_unequal", (AstMapping*)mm);
         mm = astAnnul(mm);
     }
@@ -1473,7 +1473,7 @@ static void gen_negative_fixtures(const char *dir) {
     /* matrixmap-06: full MatrixMap with non-zero off-diagonal — stays full */
     {
         double mat[] = {1.0, 2.0, 3.0, 4.0};
-        AstMatrixMap *mm = astMatrixMap(2, 2, 0, mat, "");
+        AstMatrixMap *mm = astMatrixMap(2, 2, 0, mat, " ");
         write_negative_fixture(dir, "neg_matrix_full_offdiag", (AstMapping*)mm);
         mm = astAnnul(mm);
     }
@@ -1481,9 +1481,9 @@ static void gen_negative_fixtures(const char *dir) {
     /* matrixmap-17: full MatrixMap in parallel — no merge attempted */
     {
         double mat[] = {1.0, 2.0, 3.0, 4.0};
-        AstMatrixMap *mm = astMatrixMap(2, 2, 0, mat, "");
-        AstZoomMap *zm = astZoomMap(1, 5.0, "");
-        AstCmpMap *cm = astCmpMap(mm, zm, 0, "");
+        AstMatrixMap *mm = astMatrixMap(2, 2, 0, mat, " ");
+        AstZoomMap *zm = astZoomMap(1, 5.0, " ");
+        AstCmpMap *cm = astCmpMap(mm, zm, 0, " ");
         write_negative_fixture(dir, "neg_matrix_parallel_no_merge", (AstMapping*)cm);
         cm = astAnnul(cm); mm = astAnnul(mm); zm = astAnnul(zm);
     }
@@ -1495,9 +1495,9 @@ static void gen_negative_fixtures(const char *dir) {
         double outa[] = {1, 2}, outb[] = {4, 6};
         const char *fwd[] = {"y1 = x1", "y2 = x2"};
         const char *inv[] = {"x1 = y1", "x2 = y2"};
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstMathMap *mm = astMathMap(2, 2, 2, fwd, 2, inv, "");
-        AstCmpMap *cm = astCmpMap(wm, mm, 1, "");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstMathMap *mm = astMathMap(2, 2, 2, fwd, 2, inv, " ");
+        AstCmpMap *cm = astCmpMap(wm, mm, 1, " ");
         write_negative_fixture(dir, "neg_win_nonmergeable_series", (AstMapping*)cm);
         cm = astAnnul(cm); wm = astAnnul(wm); mm = astAnnul(mm);
     }
@@ -1507,9 +1507,9 @@ static void gen_negative_fixtures(const char *dir) {
         double ina[] = {0, 0}, inb[] = {1, 1};
         double outa[] = {1, 2}, outb[] = {4, 6};
         double mat[] = {1.0, 2.0, 3.0, 4.0};
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstMatrixMap *mm = astMatrixMap(2, 2, 0, mat, "");
-        AstCmpMap *cm = astCmpMap(wm, mm, 0, "");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstMatrixMap *mm = astMatrixMap(2, 2, 0, mat, " ");
+        AstCmpMap *cm = astCmpMap(wm, mm, 0, " ");
         write_negative_fixture(dir, "neg_win_nonmergeable_parallel", (AstMapping*)cm);
         cm = astAnnul(cm); wm = astAnnul(wm); mm = astAnnul(mm);
     }
@@ -1519,7 +1519,7 @@ static void gen_negative_fixtures(const char *dir) {
         double coeff_f[] = {2.0, 1, 2, 0,
                             3.0, 1, 0, 1};
         int ncoeff_f = 2;
-        AstPolyMap *pm = astPolyMap(2, 1, ncoeff_f, coeff_f, 0, NULL, "");
+        AstPolyMap *pm = astPolyMap(2, 1, ncoeff_f, coeff_f, 0, NULL, " ");
         write_negative_fixture(dir, "neg_poly_nonlinear", (AstMapping*)pm);
         pm = astAnnul(pm);
     }
@@ -1527,9 +1527,9 @@ static void gen_negative_fixtures(const char *dir) {
     /* polymap-09: two forward non-linear PolyMaps in series — same direction refuses */
     {
         double coeff_f[] = {1.0, 1, 2};
-        AstPolyMap *p1 = astPolyMap(1, 1, 1, coeff_f, 0, NULL, "");
-        AstPolyMap *p2 = astPolyMap(1, 1, 1, coeff_f, 0, NULL, "");
-        AstCmpMap *cm = astCmpMap(p1, p2, 1, "");
+        AstPolyMap *p1 = astPolyMap(1, 1, 1, coeff_f, 0, NULL, " ");
+        AstPolyMap *p2 = astPolyMap(1, 1, 1, coeff_f, 0, NULL, " ");
+        AstCmpMap *cm = astCmpMap(p1, p2, 1, " ");
         write_negative_fixture(dir, "neg_poly_same_direction", (AstMapping*)cm);
         cm = astAnnul(cm); p1 = astAnnul(p1); p2 = astAnnul(p2);
     }
@@ -1541,7 +1541,7 @@ static void gen_negative_fixtures(const char *dir) {
         AstMathMap *m1 = astMathMap(1, 1, 1, fwd, 1, inv, "SimpFI=0,SimpIF=0");
         AstMathMap *m2 = astMathMap(1, 1, 1, fwd, 1, inv, "SimpFI=0,SimpIF=0");
         astInvert(m2);
-        AstCmpMap *cm = astCmpMap(m1, m2, 1, "");
+        AstCmpMap *cm = astCmpMap(m1, m2, 1, " ");
         write_negative_fixture(dir, "neg_math_no_simpfi", (AstMapping*)cm);
         cm = astAnnul(cm); m1 = astAnnul(m1); m2 = astAnnul(m2);
     }
@@ -1550,7 +1550,7 @@ static void gen_negative_fixtures(const char *dir) {
     {
         double args1[] = {1950.0};
         double args2[] = {2000.0};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "ADDET", 1, args1);
         astSlaAdd(sm, "SUBET", 1, args2);
         write_negative_fixture(dir, "neg_sla_arg_mismatch", (AstMapping*)sm);
@@ -1561,7 +1561,7 @@ static void gen_negative_fixtures(const char *dir) {
     {
         double rf1[] = {1.4e9, 0.0};
         double rf2[] = {2.0e9, 0.0};
-        AstSpecMap *sm = astSpecMap(1, 0, "");
+        AstSpecMap *sm = astSpecMap(1, 0, " ");
         astSpecAdd(sm, "FRTOVL", 1, rf1);
         astSpecAdd(sm, "VLTOFR", 1, rf2);
         write_negative_fixture(dir, "neg_spec_arg_mismatch", (AstMapping*)sm);
@@ -1572,7 +1572,7 @@ static void gen_negative_fixtures(const char *dir) {
     {
         double dut1[] = {0.5, 0.0};
         double dut2[] = {0.3, 0.0};
-        AstTimeMap *tm = astTimeMap(0, "");
+        AstTimeMap *tm = astTimeMap(0, " ");
         astTimeAdd(tm, "TAITOTT", 1, dut1);
         astTimeAdd(tm, "TTTOTAI", 1, dut2);
         write_negative_fixture(dir, "neg_time_arg_mismatch", (AstMapping*)tm);
@@ -1584,8 +1584,8 @@ static void gen_negative_fixtures(const char *dir) {
     {
         if (!astOK) astClearStatus;
         AstSphMap *sm = astSphMap("UnitRadius=1");
-        AstZoomMap *zm = astZoomMap(2, 2.0, "");
-        AstCmpMap *cm = astCmpMap(sm, zm, 1, "");
+        AstZoomMap *zm = astZoomMap(2, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(sm, zm, 1, " ");
         write_negative_fixture(dir, "neg_sph_non_sphmap_neighbour", (AstMapping*)cm);
         cm = astAnnul(cm); sm = astAnnul(sm); zm = astAnnul(zm);
     }
@@ -1593,9 +1593,9 @@ static void gen_negative_fixtures(const char *dir) {
     /* grismmap-08: two GrismMaps same direction — refuses cancel */
     {
         if (!astOK) astClearStatus;
-        AstGrismMap *g1 = astGrismMap("");
-        AstGrismMap *g2 = astGrismMap("");
-        AstCmpMap *cm = astCmpMap(g1, g2, 1, "");
+        AstGrismMap *g1 = astGrismMap(" ");
+        AstGrismMap *g2 = astGrismMap(" ");
+        AstCmpMap *cm = astCmpMap(g1, g2, 1, " ");
         write_negative_fixture(dir, "neg_grism_same_direction", (AstMapping*)cm);
         cm = astAnnul(cm); g1 = astAnnul(g1); g2 = astAnnul(g2);
     }
@@ -1603,9 +1603,9 @@ static void gen_negative_fixtures(const char *dir) {
     /* wcsmap-08: two WcsMaps same direction — refuses cancel */
     {
         if (!astOK) astClearStatus;
-        AstWcsMap *w1 = astWcsMap(2, AST__TAN, 1, 2, "");
-        AstWcsMap *w2 = astWcsMap(2, AST__TAN, 1, 2, "");
-        AstCmpMap *cm = astCmpMap(w1, w2, 1, "");
+        AstWcsMap *w1 = astWcsMap(2, AST__TAN, 1, 2, " ");
+        AstWcsMap *w2 = astWcsMap(2, AST__TAN, 1, 2, " ");
+        AstCmpMap *cm = astCmpMap(w1, w2, 1, " ");
         write_negative_fixture(dir, "neg_wcs_same_direction", (AstMapping*)cm);
         cm = astAnnul(cm); w1 = astAnnul(w1); w2 = astAnnul(w2);
     }
@@ -1614,7 +1614,7 @@ static void gen_negative_fixtures(const char *dir) {
     {
         double args1[] = {1950.0, 1975.0};
         double args2[] = {2000.0, 2025.0};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "PREC", 2, args1);
         astSlaAdd(sm, "PREC", 2, args2);
         write_negative_fixture(dir, "neg_sla_prec_no_common", (AstMapping*)sm);
@@ -1626,9 +1626,9 @@ static void gen_negative_fixtures(const char *dir) {
         double centre[] = {1.0, 2.0};
         double ina[] = {0, 0}, inb[] = {1, 1};
         double outa[] = {0, 0}, outb[] = {2, 3};
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstUnitNormMap *unm = astUnitNormMap(2, centre, "");
-        AstCmpMap *cm = astCmpMap(wm, unm, 1, "");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstUnitNormMap *unm = astUnitNormMap(2, centre, " ");
+        AstCmpMap *cm = astCmpMap(wm, unm, 1, " ");
         write_negative_fixture(dir, "neg_unitnormmap_nonunit_scale", (AstMapping*)cm);
         cm = astAnnul(cm); wm = astAnnul(wm); unm = astAnnul(unm);
     }
@@ -1645,8 +1645,8 @@ static void gen_negative_fixtures_2(const char *dir) {
     {
         if (!astOK) astClearStatus;
         AstSphMap *sm = astSphMap("UnitRadius=1");
-        AstZoomMap *zm = astZoomMap(2, 2.0, "");
-        AstCmpMap *cm = astCmpMap(sm, zm, 1, "");
+        AstZoomMap *zm = astZoomMap(2, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(sm, zm, 1, " ");
         write_negative_fixture(dir, "neg_zoom_no_absorb", (AstMapping*)cm);
         cm = astAnnul(cm); sm = astAnnul(sm); zm = astAnnul(zm);
     }
@@ -1655,7 +1655,7 @@ static void gen_negative_fixtures_2(const char *dir) {
     {
         if (!astOK) astClearStatus;
         double lut[] = {0.0, 1.0, 4.0, 9.0, 16.0};
-        AstLutMap *lm = astLutMap(5, lut, 1.0, 1.0, "");
+        AstLutMap *lm = astLutMap(5, lut, 1.0, 1.0, " ");
         write_negative_fixture(dir, "neg_lut_nonlinear", (AstMapping*)lm);
         lm = astAnnul(lm);
     }
@@ -1665,10 +1665,10 @@ static void gen_negative_fixtures_2(const char *dir) {
         if (!astOK) astClearStatus;
         double lut1[] = {0.0, 1.0, 4.0, 9.0, 16.0};
         double lut2[] = {0.0, 2.0, 6.0, 12.0, 20.0};
-        AstLutMap *l1 = astLutMap(5, lut1, 1.0, 1.0, "");
-        AstLutMap *l2 = astLutMap(5, lut2, 1.0, 1.0, "");
+        AstLutMap *l1 = astLutMap(5, lut1, 1.0, 1.0, " ");
+        AstLutMap *l2 = astLutMap(5, lut2, 1.0, 1.0, " ");
         astInvert(l2);
-        AstCmpMap *cm = astCmpMap(l1, l2, 1, "");
+        AstCmpMap *cm = astCmpMap(l1, l2, 1, " ");
         write_negative_fixture(dir, "neg_lut_different_tables", (AstMapping*)cm);
         cm = astAnnul(cm); l1 = astAnnul(l1); l2 = astAnnul(l2);
     }
@@ -1677,9 +1677,9 @@ static void gen_negative_fixtures_2(const char *dir) {
     {
         if (!astOK) astClearStatus;
         double cen[] = {0.0, 0.0};
-        AstPcdMap *p1 = astPcdMap(0.001, cen, "");
-        AstPcdMap *p2 = astPcdMap(0.002, cen, "");
-        AstCmpMap *cm = astCmpMap(p1, p2, 0, "");
+        AstPcdMap *p1 = astPcdMap(0.001, cen, " ");
+        AstPcdMap *p2 = astPcdMap(0.002, cen, " ");
+        AstCmpMap *cm = astCmpMap(p1, p2, 0, " ");
         write_negative_fixture(dir, "neg_pcd_parallel", (AstMapping*)cm);
         cm = astAnnul(cm); p1 = astAnnul(p1); p2 = astAnnul(p2);
     }
@@ -1689,9 +1689,9 @@ static void gen_negative_fixtures_2(const char *dir) {
         if (!astOK) astClearStatus;
         double cen[] = {0.0, 0.0};
         double shifts[] = {1.0, 2.0};
-        AstPcdMap *pm = astPcdMap(0.001, cen, "");
-        AstShiftMap *sm = astShiftMap(2, shifts, "");
-        AstCmpMap *cm = astCmpMap(pm, sm, 1, "");
+        AstPcdMap *pm = astPcdMap(0.001, cen, " ");
+        AstShiftMap *sm = astShiftMap(2, shifts, " ");
+        AstCmpMap *cm = astCmpMap(pm, sm, 1, " ");
         write_negative_fixture(dir, "neg_pcd_nonpcd_neighbour", (AstMapping*)cm);
         cm = astAnnul(cm); pm = astAnnul(pm); sm = astAnnul(sm);
     }
@@ -1699,11 +1699,11 @@ static void gen_negative_fixtures_2(const char *dir) {
     /* cmpmap-04: series CmpMap in parallel list — mode mismatch refuses decomposition */
     {
         if (!astOK) astClearStatus;
-        AstZoomMap *z1 = astZoomMap(1, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(1, 3.0, "");
-        AstCmpMap *series_inner = astCmpMap(z1, z2, 1, "");
-        AstZoomMap *z3 = astZoomMap(1, 5.0, "");
-        AstCmpMap *par = astCmpMap(series_inner, z3, 0, "");
+        AstZoomMap *z1 = astZoomMap(1, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(1, 3.0, " ");
+        AstCmpMap *series_inner = astCmpMap(z1, z2, 1, " ");
+        AstZoomMap *z3 = astZoomMap(1, 5.0, " ");
+        AstCmpMap *par = astCmpMap(series_inner, z3, 0, " ");
         write_negative_fixture(dir, "neg_cmpmap_mode_mismatch", (AstMapping*)par);
         par = astAnnul(par); series_inner = astAnnul(series_inner);
         z1 = astAnnul(z1); z2 = astAnnul(z2); z3 = astAnnul(z3);
@@ -1712,10 +1712,10 @@ static void gen_negative_fixtures_2(const char *dir) {
     /* wcsmap-07: WcsMap adjacent to different projection type — refuses merge */
     {
         if (!astOK) astClearStatus;
-        AstWcsMap *w1 = astWcsMap(2, AST__TAN, 1, 2, "");
-        AstWcsMap *w2 = astWcsMap(2, AST__SIN, 1, 2, "");
+        AstWcsMap *w1 = astWcsMap(2, AST__TAN, 1, 2, " ");
+        AstWcsMap *w2 = astWcsMap(2, AST__SIN, 1, 2, " ");
         astInvert(w2);
-        AstCmpMap *cm = astCmpMap(w1, w2, 1, "");
+        AstCmpMap *cm = astCmpMap(w1, w2, 1, " ");
         write_negative_fixture(dir, "neg_wcs_different_projection", (AstMapping*)cm);
         cm = astAnnul(cm); w1 = astAnnul(w1); w2 = astAnnul(w2);
     }
@@ -1723,9 +1723,9 @@ static void gen_negative_fixtures_2(const char *dir) {
     /* tranmap-07: TranMap with unequal components — not simplified */
     {
         if (!astOK) astClearStatus;
-        AstZoomMap *z1 = astZoomMap(1, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(1, 3.0, "");
-        AstTranMap *tm = astTranMap(z1, z2, "");
+        AstZoomMap *z1 = astZoomMap(1, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(1, 3.0, " ");
+        AstTranMap *tm = astTranMap(z1, z2, " ");
         write_negative_fixture(dir, "neg_tranmap_unequal_components", (AstMapping*)tm);
         tm = astAnnul(tm); z1 = astAnnul(z1); z2 = astAnnul(z2);
     }
@@ -1735,9 +1735,9 @@ static void gen_negative_fixtures_2(const char *dir) {
         if (!astOK) astClearStatus;
         double tx[] = {0, 1}, ty[] = {0, 1};
         double cu[] = {1.5}, cv[] = {2.5};
-        AstSplineMap *s1 = astSplineMap(1, 1, 1, 1, tx, ty, cu, cv, "");
-        AstSplineMap *s2 = astSplineMap(1, 1, 1, 1, tx, ty, cu, cv, "");
-        AstCmpMap *cm = astCmpMap(s1, s2, 1, "");
+        AstSplineMap *s1 = astSplineMap(1, 1, 1, 1, tx, ty, cu, cv, " ");
+        AstSplineMap *s2 = astSplineMap(1, 1, 1, 1, tx, ty, cu, cv, " ");
+        AstCmpMap *cm = astCmpMap(s1, s2, 1, " ");
         write_negative_fixture(dir, "neg_spline_same_direction", (AstMapping*)cm);
         cm = astAnnul(cm); s1 = astAnnul(s1); s2 = astAnnul(s2);
     }
@@ -1745,10 +1745,10 @@ static void gen_negative_fixtures_2(const char *dir) {
     /* normmap-11: NormMap in parallel — no simplification */
     {
         if (!astOK) astClearStatus;
-        AstSkyFrame *sf = astSkyFrame("");
-        AstNormMap *nm = astNormMap(sf, "");
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstCmpMap *cm = astCmpMap(nm, zm, 0, "");
+        AstSkyFrame *sf = astSkyFrame(" ");
+        AstNormMap *nm = astNormMap(sf, " ");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(nm, zm, 0, " ");
         write_negative_fixture(dir, "neg_normmap_parallel", (AstMapping*)cm);
         cm = astAnnul(cm); nm = astAnnul(nm); zm = astAnnul(zm);
         sf = astAnnul(sf);
@@ -1761,9 +1761,9 @@ static void gen_negative_fixtures_2(const char *dir) {
         int outperm[] = {2, 1};
         const char *fwd[] = {"y1 = x1", "y2 = x2"};
         const char *inv[] = {"x1 = y1", "x2 = y2"};
-        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, NULL, "");
-        AstMathMap *mm = astMathMap(2, 2, 2, fwd, 2, inv, "");
-        AstCmpMap *cm = astCmpMap(pm, mm, 1, "");
+        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, NULL, " ");
+        AstMathMap *mm = astMathMap(2, 2, 2, fwd, 2, inv, " ");
+        AstCmpMap *cm = astCmpMap(pm, mm, 1, " ");
         write_negative_fixture(dir, "neg_perm_no_merge", (AstMapping*)cm);
         cm = astAnnul(cm); pm = astAnnul(pm); mm = astAnnul(mm);
     }
@@ -1780,11 +1780,11 @@ static void gen_negative_fixtures_3(const char *dir) {
         if (!astOK) astClearStatus;
         double ina[] = {0, 0}, inb[] = {1, 1};
         double outa[] = {1, 2}, outb[] = {4, 6};
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstZoomMap *z1 = astZoomMap(2, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(2, 3.0, "");
-        AstCmpMap *series = astCmpMap(z1, z2, 1, "");
-        AstCmpMap *cm = astCmpMap(series, wm, 1, "");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstZoomMap *z1 = astZoomMap(2, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(2, 3.0, " ");
+        AstCmpMap *series = astCmpMap(z1, z2, 1, " ");
+        AstCmpMap *cm = astCmpMap(series, wm, 1, " ");
         write_negative_fixture(dir, "neg_win_series_cmpmap_neighbour", (AstMapping*)cm);
         cm = astAnnul(cm); series = astAnnul(series);
         wm = astAnnul(wm); z1 = astAnnul(z1); z2 = astAnnul(z2);
@@ -1796,9 +1796,9 @@ static void gen_negative_fixtures_3(const char *dir) {
         double ina[] = {0, 0}, inb[] = {1, 1};
         double outa[] = {1, 2}, outb[] = {4, 6};
         double mat[] = {1.0, 2.0, 3.0, 4.0};
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstMatrixMap *mm = astMatrixMap(2, 2, 0, mat, "");
-        AstCmpMap *cm = astCmpMap(wm, mm, 1, "");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstMatrixMap *mm = astMatrixMap(2, 2, 0, mat, " ");
+        AstCmpMap *cm = astCmpMap(wm, mm, 1, " ");
         write_negative_fixture(dir, "neg_win_swap_no_simplify", (AstMapping*)cm);
         cm = astAnnul(cm); wm = astAnnul(wm); mm = astAnnul(mm);
     }
@@ -1810,9 +1810,9 @@ static void gen_negative_fixtures_3(const char *dir) {
         int inperm[] = {1, -1};
         int outperm[] = {1, -1};
         double consts[] = {5.0, 7.0};
-        AstMatrixMap *mm = astMatrixMap(2, 2, 1, diag, "");
-        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, consts, "");
-        AstCmpMap *cm = astCmpMap(mm, pm, 1, "");
+        AstMatrixMap *mm = astMatrixMap(2, 2, 1, diag, " ");
+        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, consts, " ");
+        AstCmpMap *cm = astCmpMap(mm, pm, 1, " ");
         write_negative_fixture(dir, "neg_matrix_perm_not_bidirectional", (AstMapping*)cm);
         cm = astAnnul(cm); mm = astAnnul(mm); pm = astAnnul(pm);
     }
@@ -1820,10 +1820,10 @@ static void gen_negative_fixtures_3(const char *dir) {
     /* ratemap-09: RateMap where upper neighbour is not a RateMap */
     {
         if (!astOK) astClearStatus;
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstRateMap *rm = astRateMap(zm, 1, 1, "");
-        AstZoomMap *z2 = astZoomMap(1, 3.0, "");
-        AstCmpMap *cm = astCmpMap(rm, z2, 1, "");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstRateMap *rm = astRateMap(zm, 1, 1, " ");
+        AstZoomMap *z2 = astZoomMap(1, 3.0, " ");
+        AstCmpMap *cm = astCmpMap(rm, z2, 1, " ");
         write_negative_fixture(dir, "neg_ratemap_nonratemap_neighbour", (AstMapping*)cm);
         cm = astAnnul(cm); rm = astAnnul(rm); z2 = astAnnul(z2);
         zm = astAnnul(zm);
@@ -1832,12 +1832,12 @@ static void gen_negative_fixtures_3(const char *dir) {
     /* ratemap-08: RateMaps with different encapsulated Mappings */
     {
         if (!astOK) astClearStatus;
-        AstZoomMap *z1 = astZoomMap(2, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(2, 3.0, "");
-        AstRateMap *r1 = astRateMap(z1, 1, 1, "");
-        AstRateMap *r2 = astRateMap(z2, 1, 1, "");
+        AstZoomMap *z1 = astZoomMap(2, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(2, 3.0, " ");
+        AstRateMap *r1 = astRateMap(z1, 1, 1, " ");
+        AstRateMap *r2 = astRateMap(z2, 1, 1, " ");
         astInvert(r2);
-        AstCmpMap *cm = astCmpMap(r1, r2, 1, "");
+        AstCmpMap *cm = astCmpMap(r1, r2, 1, " ");
         write_negative_fixture(dir, "neg_ratemap_different_inner", (AstMapping*)cm);
         cm = astAnnul(cm); r1 = astAnnul(r1); r2 = astAnnul(r2);
         z1 = astAnnul(z1); z2 = astAnnul(z2);
@@ -1846,13 +1846,13 @@ static void gen_negative_fixtures_3(const char *dir) {
     /* cmpmap-06: CmpMap neighbour is not a CmpMap — refuses merge */
     {
         if (!astOK) astClearStatus;
-        AstZoomMap *z1 = astZoomMap(1, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(1, 3.0, "");
-        AstCmpMap *par = astCmpMap(z1, z2, 0, "");
+        AstZoomMap *z1 = astZoomMap(1, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(1, 3.0, " ");
+        AstCmpMap *par = astCmpMap(z1, z2, 0, " ");
         const char *fwd[] = {"y1 = x1", "y2 = x2"};
         const char *inv[] = {"x1 = y1", "x2 = y2"};
-        AstMathMap *mm = astMathMap(2, 2, 2, fwd, 2, inv, "");
-        AstCmpMap *cm = astCmpMap(par, mm, 1, "");
+        AstMathMap *mm = astMathMap(2, 2, 2, fwd, 2, inv, " ");
+        AstCmpMap *cm = astCmpMap(par, mm, 1, " ");
         write_negative_fixture(dir, "neg_cmpmap_neighbour_not_cmpmap", (AstMapping*)cm);
         cm = astAnnul(cm); par = astAnnul(par); mm = astAnnul(mm);
         z1 = astAnnul(z1); z2 = astAnnul(z2);
@@ -1864,7 +1864,7 @@ static void gen_negative_fixtures_3(const char *dir) {
         AstSphMap *s1 = astSphMap("PolarLong=0");
         astInvert(s1);
         AstSphMap *s2 = astSphMap("PolarLong=3.14159");
-        AstCmpMap *cm = astCmpMap(s1, s2, 1, "");
+        AstCmpMap *cm = astCmpMap(s1, s2, 1, " ");
         write_negative_fixture(dir, "neg_sph_polarlong_mismatch", (AstMapping*)cm);
         cm = astAnnul(cm); s1 = astAnnul(s1); s2 = astAnnul(s2);
     }
@@ -1872,10 +1872,10 @@ static void gen_negative_fixtures_3(const char *dir) {
     /* sphmap-04: SphMap(fwd) + Inverse(SphMap) but UnitRadius not set */
     {
         if (!astOK) astClearStatus;
-        AstSphMap *s1 = astSphMap("");
-        AstSphMap *s2 = astSphMap("");
+        AstSphMap *s1 = astSphMap(" ");
+        AstSphMap *s2 = astSphMap(" ");
         astInvert(s2);
-        AstCmpMap *cm = astCmpMap(s1, s2, 1, "");
+        AstCmpMap *cm = astCmpMap(s1, s2, 1, " ");
         write_negative_fixture(dir, "neg_sph_no_unitradius", (AstMapping*)cm);
         cm = astAnnul(cm); s1 = astAnnul(s1); s2 = astAnnul(s2);
     }
@@ -1885,10 +1885,10 @@ static void gen_negative_fixtures_3(const char *dir) {
         if (!astOK) astClearStatus;
         double coeff_f1[] = {2.0, 1, 1};
         double coeff_f2[] = {3.0, 1, 1};
-        AstPolyMap *p1 = astPolyMap(1, 1, 1, coeff_f1, 0, NULL, "");
-        AstPolyMap *p2 = astPolyMap(1, 1, 1, coeff_f2, 0, NULL, "");
+        AstPolyMap *p1 = astPolyMap(1, 1, 1, coeff_f1, 0, NULL, " ");
+        AstPolyMap *p2 = astPolyMap(1, 1, 1, coeff_f2, 0, NULL, " ");
         astInvert(p2);
-        AstCmpMap *cm = astCmpMap(p1, p2, 1, "");
+        AstCmpMap *cm = astCmpMap(p1, p2, 1, " ");
         write_negative_fixture(dir, "neg_poly_different_coeffs", (AstMapping*)cm);
         cm = astAnnul(cm); p1 = astAnnul(p1); p2 = astAnnul(p2);
     }
@@ -1897,9 +1897,9 @@ static void gen_negative_fixtures_3(const char *dir) {
     {
         if (!astOK) astClearStatus;
         double lut[] = {0.0, 1.0, 4.0, 9.0, 16.0};
-        AstLutMap *l1 = astLutMap(5, lut, 1.0, 1.0, "");
-        AstLutMap *l2 = astLutMap(5, lut, 1.0, 1.0, "");
-        AstCmpMap *cm = astCmpMap(l1, l2, 0, "");
+        AstLutMap *l1 = astLutMap(5, lut, 1.0, 1.0, " ");
+        AstLutMap *l2 = astLutMap(5, lut, 1.0, 1.0, " ");
+        AstCmpMap *cm = astCmpMap(l1, l2, 0, " ");
         write_negative_fixture(dir, "neg_lut_parallel", (AstMapping*)cm);
         cm = astAnnul(cm); l1 = astAnnul(l1); l2 = astAnnul(l2);
     }
@@ -1916,7 +1916,7 @@ static void gen_negative_fixtures_4(const char *dir) {
         if (!astOK) astClearStatus;
         double amp_args[] = {51544.0, 2000.0};
         double map_args[] = {2001.0, 51544.0};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "AMP", 2, amp_args);
         astSlaAdd(sm, "MAP", 2, map_args);
         write_negative_fixture(dir, "neg_sla_2arg_mismatch", (AstMapping*)sm);
@@ -1928,7 +1928,7 @@ static void gen_negative_fixtures_4(const char *dir) {
         if (!astOK) astClearStatus;
         double args1[] = {0.5, 1.2, 0.0, 0.0};
         double args2[] = {0.5, 1.3, 0.0, 0.0};
-        AstSpecMap *sm = astSpecMap(1, 0, "");
+        AstSpecMap *sm = astSpecMap(1, 0, " ");
         astSpecAdd(sm, "LKF2HL", 2, args1);
         astSpecAdd(sm, "HLF2LK", 2, args2);
         write_negative_fixture(dir, "neg_spec_2arg_mismatch", (AstMapping*)sm);
@@ -1940,7 +1940,7 @@ static void gen_negative_fixtures_4(const char *dir) {
         if (!astOK) astClearStatus;
         double args1[] = {0.5, 1.2, 51544.0, 0.0, 0.0};
         double args2[] = {0.5, 1.2, 51545.0, 0.0, 0.0};
-        AstSpecMap *sm = astSpecMap(1, 0, "");
+        AstSpecMap *sm = astSpecMap(1, 0, " ");
         astSpecAdd(sm, "GEF2HL", 3, args1);
         astSpecAdd(sm, "HLF2GE", 3, args2);
         write_negative_fixture(dir, "neg_spec_3arg_mismatch", (AstMapping*)sm);
@@ -1952,7 +1952,7 @@ static void gen_negative_fixtures_4(const char *dir) {
         if (!astOK) astClearStatus;
         double args1[] = {0.0, 2400000.5, 0.0};
         double args2[] = {2400001.0, 0.0, 0.0};
-        AstTimeMap *tm = astTimeMap(0, "");
+        AstTimeMap *tm = astTimeMap(0, " ");
         astTimeAdd(tm, "MJDTOJD", 2, args1);
         astTimeAdd(tm, "JDTOMJD", 2, args2);
         write_negative_fixture(dir, "neg_time_2arg_mismatch", (AstMapping*)tm);
@@ -1964,7 +1964,7 @@ static void gen_negative_fixtures_4(const char *dir) {
         if (!astOK) astClearStatus;
         double args1[] = {-2.5, 1000.0, 1013.0, 0.0};
         double args2[] = {-2.6, 1000.0, 1013.0, 0.0};
-        AstTimeMap *tm = astTimeMap(0, "");
+        AstTimeMap *tm = astTimeMap(0, " ");
         astTimeAdd(tm, "GMSTTOLMST", 3, args1);
         astTimeAdd(tm, "LMSTTOGMST", 3, args2);
         write_negative_fixture(dir, "neg_time_3arg_mismatch", (AstMapping*)tm);
@@ -1977,7 +1977,7 @@ static void gen_negative_fixtures_4(const char *dir) {
         AstGrismMap *g1 = astGrismMap("GrismNR=1.0");
         AstGrismMap *g2 = astGrismMap("GrismNR=1.5");
         astInvert(g2);
-        AstCmpMap *cm = astCmpMap(g1, g2, 1, "");
+        AstCmpMap *cm = astCmpMap(g1, g2, 1, " ");
         write_negative_fixture(dir, "neg_grism_different_attrs", (AstMapping*)cm);
         cm = astAnnul(cm); g1 = astAnnul(g1); g2 = astAnnul(g2);
     }
@@ -1987,10 +1987,10 @@ static void gen_negative_fixtures_4(const char *dir) {
         if (!astOK) astClearStatus;
         AstSkyFrame *sf1 = astSkyFrame("System=FK5");
         AstSkyFrame *sf2 = astSkyFrame("System=FK4");
-        AstNormMap *n1 = astNormMap(sf1, "");
-        AstNormMap *n2 = astNormMap(sf2, "");
+        AstNormMap *n1 = astNormMap(sf1, " ");
+        AstNormMap *n2 = astNormMap(sf2, " ");
         astInvert(n1);
-        AstCmpMap *cm = astCmpMap(n1, n2, 1, "");
+        AstCmpMap *cm = astCmpMap(n1, n2, 1, " ");
         write_negative_fixture(dir, "neg_normmap_different_frames", (AstMapping*)cm);
         cm = astAnnul(cm); n1 = astAnnul(n1); n2 = astAnnul(n2);
         sf1 = astAnnul(sf1); sf2 = astAnnul(sf2);
@@ -2001,9 +2001,9 @@ static void gen_negative_fixtures_4(const char *dir) {
         if (!astOK) astClearStatus;
         double c1[] = {1.0, 2.0};
         double c2[] = {3.0, 4.0};
-        AstUnitNormMap *u1 = astUnitNormMap(2, c1, "");
-        AstUnitNormMap *u2 = astUnitNormMap(2, c2, "");
-        AstCmpMap *cm = astCmpMap(u1, u2, 1, "");
+        AstUnitNormMap *u1 = astUnitNormMap(2, c1, " ");
+        AstUnitNormMap *u2 = astUnitNormMap(2, c2, " ");
+        AstCmpMap *cm = astCmpMap(u1, u2, 1, " ");
         write_negative_fixture(dir, "neg_unitnormmap_same_direction", (AstMapping*)cm);
         cm = astAnnul(cm); u1 = astAnnul(u1); u2 = astAnnul(u2);
     }
@@ -2013,9 +2013,9 @@ static void gen_negative_fixtures_4(const char *dir) {
         if (!astOK) astClearStatus;
         double centre[] = {1.0, 2.0};
         double shifts[] = {0.5, 0.5};
-        AstUnitNormMap *unm = astUnitNormMap(2, centre, "");
-        AstShiftMap *sm = astShiftMap(2, shifts, "");
-        AstCmpMap *cm = astCmpMap(unm, sm, 1, "");
+        AstUnitNormMap *unm = astUnitNormMap(2, centre, " ");
+        AstShiftMap *sm = astShiftMap(2, shifts, " ");
+        AstCmpMap *cm = astCmpMap(unm, sm, 1, " ");
         write_negative_fixture(dir, "neg_unitnormmap_fwd_then_shift", (AstMapping*)cm);
         cm = astAnnul(cm); unm = astAnnul(unm); sm = astAnnul(sm);
     }
@@ -2026,7 +2026,7 @@ static void gen_negative_fixtures_4(const char *dir) {
         AstWcsMap *w1 = astWcsMap(2, AST__TAN, 1, 2, "PV1_1=0.5");
         AstWcsMap *w2 = astWcsMap(2, AST__TAN, 1, 2, "PV1_1=1.0");
         astInvert(w2);
-        AstCmpMap *cm = astCmpMap(w1, w2, 1, "");
+        AstCmpMap *cm = astCmpMap(w1, w2, 1, " ");
         write_negative_fixture(dir, "neg_wcs_different_params", (AstMapping*)cm);
         cm = astAnnul(cm); w1 = astAnnul(w1); w2 = astAnnul(w2);
     }
@@ -2034,7 +2034,7 @@ static void gen_negative_fixtures_4(const char *dir) {
     /* slamap-06: single forward SlaMap with no neighbours — nothing simplifies */
     {
         if (!astOK) astClearStatus;
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "EQGAL", 0, NULL);
         write_negative_fixture(dir, "neg_sla_lone_forward", (AstMapping*)sm);
         sm = astAnnul(sm);
@@ -2050,10 +2050,10 @@ static void gen_negative_fixtures_5(const char *dir) {
     /* slamap-05: SlaMap in parallel — refuses simplification */
     {
         if (!astOK) astClearStatus;
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "EQGAL", 0, NULL);
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstCmpMap *cm = astCmpMap(sm, zm, 0, "");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(sm, zm, 0, " ");
         write_negative_fixture(dir, "neg_sla_parallel", (AstMapping*)cm);
         cm = astAnnul(cm); sm = astAnnul(sm); zm = astAnnul(zm);
     }
@@ -2062,10 +2062,10 @@ static void gen_negative_fixtures_5(const char *dir) {
     {
         if (!astOK) astClearStatus;
         double rf[] = {1.4e9, 0.0};
-        AstSpecMap *sm = astSpecMap(1, 0, "");
+        AstSpecMap *sm = astSpecMap(1, 0, " ");
         astSpecAdd(sm, "FRTOVL", 1, rf);
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstCmpMap *cm = astCmpMap(sm, zm, 0, "");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(sm, zm, 0, " ");
         write_negative_fixture(dir, "neg_spec_parallel", (AstMapping*)cm);
         cm = astAnnul(cm); sm = astAnnul(sm); zm = astAnnul(zm);
     }
@@ -2074,10 +2074,10 @@ static void gen_negative_fixtures_5(const char *dir) {
     {
         if (!astOK) astClearStatus;
         double dut[] = {0.5, 0.0};
-        AstTimeMap *tm = astTimeMap(0, "");
+        AstTimeMap *tm = astTimeMap(0, " ");
         astTimeAdd(tm, "TAITOTT", 1, dut);
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstCmpMap *cm = astCmpMap(tm, zm, 0, "");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(tm, zm, 0, " ");
         write_negative_fixture(dir, "neg_time_parallel", (AstMapping*)cm);
         cm = astAnnul(cm); tm = astAnnul(tm); zm = astAnnul(zm);
     }
@@ -2085,9 +2085,9 @@ static void gen_negative_fixtures_5(const char *dir) {
     /* grismmap-04: GrismMap in parallel — refuses */
     {
         if (!astOK) astClearStatus;
-        AstGrismMap *gm = astGrismMap("");
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstCmpMap *cm = astCmpMap(gm, zm, 0, "");
+        AstGrismMap *gm = astGrismMap(" ");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(gm, zm, 0, " ");
         write_negative_fixture(dir, "neg_grism_parallel", (AstMapping*)cm);
         cm = astAnnul(cm); gm = astAnnul(gm); zm = astAnnul(zm);
     }
@@ -2095,10 +2095,10 @@ static void gen_negative_fixtures_5(const char *dir) {
     /* grismmap-09: inverted GrismMap followed by ZoomMap — wrong order */
     {
         if (!astOK) astClearStatus;
-        AstGrismMap *gm = astGrismMap("");
+        AstGrismMap *gm = astGrismMap(" ");
         astInvert(gm);
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstCmpMap *cm = astCmpMap(gm, zm, 1, "");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(gm, zm, 1, " ");
         write_negative_fixture(dir, "neg_grism_inv_then_zoom", (AstMapping*)cm);
         cm = astAnnul(cm); gm = astAnnul(gm); zm = astAnnul(zm);
     }
@@ -2106,10 +2106,10 @@ static void gen_negative_fixtures_5(const char *dir) {
     /* grismmap-10: forward GrismMap followed by non-ZoomMap */
     {
         if (!astOK) astClearStatus;
-        AstGrismMap *gm = astGrismMap("");
+        AstGrismMap *gm = astGrismMap(" ");
         double shifts[] = {1.0};
-        AstShiftMap *sm = astShiftMap(1, shifts, "");
-        AstCmpMap *cm = astCmpMap(gm, sm, 1, "");
+        AstShiftMap *sm = astShiftMap(1, shifts, " ");
+        AstCmpMap *cm = astCmpMap(gm, sm, 1, " ");
         write_negative_fixture(dir, "neg_grism_fwd_then_nonzoom", (AstMapping*)cm);
         cm = astAnnul(cm); gm = astAnnul(gm); sm = astAnnul(sm);
     }
@@ -2120,8 +2120,8 @@ static void gen_negative_fixtures_5(const char *dir) {
         const char *fwd[] = {"y = x"};
         const char *inv[] = {"x = y"};
         AstMathMap *mm = astMathMap(1, 1, 1, fwd, 1, inv, "SimpFI=1");
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstCmpMap *cm = astCmpMap(mm, zm, 1, "");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(mm, zm, 1, " ");
         write_negative_fixture(dir, "neg_math_nonmath_neighbour", (AstMapping*)cm);
         cm = astAnnul(cm); mm = astAnnul(mm); zm = astAnnul(zm);
     }
@@ -2129,9 +2129,9 @@ static void gen_negative_fixtures_5(const char *dir) {
     /* wcsmap-06: WcsMap in parallel — refuses */
     {
         if (!astOK) astClearStatus;
-        AstWcsMap *wm = astWcsMap(2, AST__TAN, 1, 2, "");
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstCmpMap *cm = astCmpMap(wm, zm, 0, "");
+        AstWcsMap *wm = astWcsMap(2, AST__TAN, 1, 2, " ");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(wm, zm, 0, " ");
         write_negative_fixture(dir, "neg_wcs_parallel", (AstMapping*)cm);
         cm = astAnnul(cm); wm = astAnnul(wm); zm = astAnnul(zm);
     }
@@ -2140,10 +2140,10 @@ static void gen_negative_fixtures_5(const char *dir) {
     {
         if (!astOK) astClearStatus;
         double coeff_f[] = {1.0, 1, 2};
-        AstPolyMap *p1 = astPolyMap(1, 1, 1, coeff_f, 0, NULL, "");
-        AstPolyMap *p2 = astPolyMap(1, 1, 1, coeff_f, 0, NULL, "");
+        AstPolyMap *p1 = astPolyMap(1, 1, 1, coeff_f, 0, NULL, " ");
+        AstPolyMap *p2 = astPolyMap(1, 1, 1, coeff_f, 0, NULL, " ");
         astInvert(p2);
-        AstCmpMap *cm = astCmpMap(p1, p2, 0, "");
+        AstCmpMap *cm = astCmpMap(p1, p2, 0, " ");
         write_negative_fixture(dir, "neg_poly_parallel_nonlinear", (AstMapping*)cm);
         cm = astAnnul(cm); p1 = astAnnul(p1); p2 = astAnnul(p2);
     }
@@ -2153,9 +2153,9 @@ static void gen_negative_fixtures_5(const char *dir) {
         if (!astOK) astClearStatus;
         double tx[] = {0, 1}, ty[] = {0, 1};
         double cu[] = {1.5}, cv[] = {2.5};
-        AstSplineMap *sm = astSplineMap(1, 1, 1, 1, tx, ty, cu, cv, "");
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstCmpMap *cm = astCmpMap(sm, zm, 0, "");
+        AstSplineMap *sm = astSplineMap(1, 1, 1, 1, tx, ty, cu, cv, " ");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(sm, zm, 0, " ");
         write_negative_fixture(dir, "neg_spline_parallel", (AstMapping*)cm);
         cm = astAnnul(cm); sm = astAnnul(sm); zm = astAnnul(zm);
     }
@@ -2164,9 +2164,9 @@ static void gen_negative_fixtures_5(const char *dir) {
     {
         if (!astOK) astClearStatus;
         double lut[] = {0.0, 1.0, 4.0, 9.0, 16.0};
-        AstLutMap *lm = astLutMap(5, lut, 1.0, 1.0, "");
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstCmpMap *cm = astCmpMap(lm, zm, 1, "");
+        AstLutMap *lm = astLutMap(5, lut, 1.0, 1.0, " ");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(lm, zm, 1, " ");
         write_negative_fixture(dir, "neg_lut_nonlut_neighbour", (AstMapping*)cm);
         cm = astAnnul(cm); lm = astAnnul(lm); zm = astAnnul(zm);
     }
@@ -2182,7 +2182,7 @@ static void gen_negative_fixtures_6(const char *dir) {
     {
         if (!astOK) astClearStatus;
         double rf[] = {1.4e9, 0.0};
-        AstSpecMap *sm = astSpecMap(1, 0, "");
+        AstSpecMap *sm = astSpecMap(1, 0, " ");
         astSpecAdd(sm, "FRTOVL", 1, rf);
         write_negative_fixture(dir, "neg_spec_lone_forward", (AstMapping*)sm);
         sm = astAnnul(sm);
@@ -2192,7 +2192,7 @@ static void gen_negative_fixtures_6(const char *dir) {
     {
         if (!astOK) astClearStatus;
         double dut[] = {0.5, 0.0};
-        AstTimeMap *tm = astTimeMap(0, "");
+        AstTimeMap *tm = astTimeMap(0, " ");
         astTimeAdd(tm, "TAITOTT", 1, dut);
         write_negative_fixture(dir, "neg_time_lone_forward", (AstMapping*)tm);
         tm = astAnnul(tm);
@@ -2201,9 +2201,9 @@ static void gen_negative_fixtures_6(const char *dir) {
     /* grismmap-13: GrismMap + ZoomMap(0) — zero zoom prevents merge */
     {
         if (!astOK) astClearStatus;
-        AstGrismMap *gm = astGrismMap("");
-        AstZoomMap *zm = astZoomMap(1, 0.0, "");
-        AstCmpMap *cm = astCmpMap(gm, zm, 1, "");
+        AstGrismMap *gm = astGrismMap(" ");
+        AstZoomMap *zm = astZoomMap(1, 0.0, " ");
+        AstCmpMap *cm = astCmpMap(gm, zm, 1, " ");
         write_negative_fixture(dir, "neg_grism_zoom_zero", (AstMapping*)cm);
         cm = astAnnul(cm); gm = astAnnul(gm); zm = astAnnul(zm);
     }
@@ -2212,9 +2212,9 @@ static void gen_negative_fixtures_6(const char *dir) {
     {
         if (!astOK) astClearStatus;
         double coeff_f[] = {1.0, 1, 2};
-        AstPolyMap *pm = astPolyMap(1, 1, 1, coeff_f, 0, NULL, "");
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstCmpMap *cm = astCmpMap(pm, zm, 1, "");
+        AstPolyMap *pm = astPolyMap(1, 1, 1, coeff_f, 0, NULL, " ");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(pm, zm, 1, " ");
         write_negative_fixture(dir, "neg_poly_nonpoly_neighbour", (AstMapping*)cm);
         cm = astAnnul(cm); pm = astAnnul(pm); zm = astAnnul(zm);
     }
@@ -2224,9 +2224,9 @@ static void gen_negative_fixtures_6(const char *dir) {
         if (!astOK) astClearStatus;
         double tx[] = {0, 1}, ty[] = {0, 1};
         double cu[] = {1.5}, cv[] = {2.5};
-        AstSplineMap *sm = astSplineMap(1, 1, 1, 1, tx, ty, cu, cv, "");
-        AstZoomMap *zm = astZoomMap(2, 2.0, "");
-        AstCmpMap *cm = astCmpMap(sm, zm, 1, "");
+        AstSplineMap *sm = astSplineMap(1, 1, 1, 1, tx, ty, cu, cv, " ");
+        AstZoomMap *zm = astZoomMap(2, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(sm, zm, 1, " ");
         write_negative_fixture(dir, "neg_spline_nonspline_neighbour", (AstMapping*)cm);
         cm = astAnnul(cm); sm = astAnnul(sm); zm = astAnnul(zm);
     }
@@ -2239,9 +2239,9 @@ static void gen_negative_fixtures_6(const char *dir) {
         double mat[] = {1.0, 2.0, 3.0, 4.0};
         double ina[] = {0, 0}, inb[] = {1, 1};
         double outa[] = {1, 2}, outb[] = {3, 5};
-        AstMatrixMap *mm = astMatrixMap(2, 2, 0, mat, "");
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstCmpMap *cm = astCmpMap(mm, wm, 1, "");
+        AstMatrixMap *mm = astMatrixMap(2, 2, 0, mat, " ");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstCmpMap *cm = astCmpMap(mm, wm, 1, " ");
         write_negative_fixture(dir, "neg_matrix_swap_refused", (AstMapping*)cm);
         cm = astAnnul(cm); mm = astAnnul(mm); wm = astAnnul(wm);
     }
@@ -2259,7 +2259,7 @@ static void gen_negative_fixtures_7(const char *dir) {
         if (!astOK) astClearStatus;
         double coeff_f[] = {3.0, 1, 1, 0,
                             5.0, 1, 0, 1};
-        AstPolyMap *pm = astPolyMap(2, 1, 2, coeff_f, 0, NULL, "");
+        AstPolyMap *pm = astPolyMap(2, 1, 2, coeff_f, 0, NULL, " ");
         write_negative_fixture(dir, "neg_poly_nin_ne_nout", (AstMapping*)pm);
         pm = astAnnul(pm);
     }
@@ -2267,13 +2267,13 @@ static void gen_negative_fixtures_7(const char *dir) {
     /* tranmap-05: TranMaps in parallel — refuses adjacent merge */
     {
         if (!astOK) astClearStatus;
-        AstZoomMap *z1 = astZoomMap(1, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(1, 0.5, "");
-        AstZoomMap *z3 = astZoomMap(1, 3.0, "");
-        AstZoomMap *z4 = astZoomMap(1, 1.0/3.0, "");
-        AstTranMap *t1 = astTranMap(z1, z2, "");
-        AstTranMap *t2 = astTranMap(z3, z4, "");
-        AstCmpMap *cm = astCmpMap(t1, t2, 0, "");
+        AstZoomMap *z1 = astZoomMap(1, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(1, 0.5, " ");
+        AstZoomMap *z3 = astZoomMap(1, 3.0, " ");
+        AstZoomMap *z4 = astZoomMap(1, 1.0/3.0, " ");
+        AstTranMap *t1 = astTranMap(z1, z2, " ");
+        AstTranMap *t2 = astTranMap(z3, z4, " ");
+        AstCmpMap *cm = astCmpMap(t1, t2, 0, " ");
         write_negative_fixture(dir, "neg_tranmap_parallel", (AstMapping*)cm);
         cm = astAnnul(cm); t1 = astAnnul(t1); t2 = astAnnul(t2);
         z1 = astAnnul(z1); z2 = astAnnul(z2);
@@ -2283,11 +2283,11 @@ static void gen_negative_fixtures_7(const char *dir) {
     /* tranmap-08: TranMap where higher neighbour is not a TranMap */
     {
         if (!astOK) astClearStatus;
-        AstZoomMap *z1 = astZoomMap(1, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(1, 0.5, "");
-        AstTranMap *tm = astTranMap(z1, z2, "");
-        AstZoomMap *z3 = astZoomMap(1, 5.0, "");
-        AstCmpMap *cm = astCmpMap(tm, z3, 1, "");
+        AstZoomMap *z1 = astZoomMap(1, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(1, 0.5, " ");
+        AstTranMap *tm = astTranMap(z1, z2, " ");
+        AstZoomMap *z3 = astZoomMap(1, 5.0, " ");
+        AstCmpMap *cm = astCmpMap(tm, z3, 1, " ");
         write_negative_fixture(dir, "neg_tranmap_nontranmap_neighbour", (AstMapping*)cm);
         cm = astAnnul(cm); tm = astAnnul(tm);
         z1 = astAnnul(z1); z2 = astAnnul(z2); z3 = astAnnul(z3);
@@ -2299,10 +2299,10 @@ static void gen_negative_fixtures_7(const char *dir) {
         double shifts[] = {1.0, 2.0, 3.0};
         AstSphMap *s1 = astSphMap("UnitRadius=1");
         astInvert(s1);
-        AstShiftMap *sm = astShiftMap(3, shifts, "");
+        AstShiftMap *sm = astShiftMap(3, shifts, " ");
         AstSphMap *s2 = astSphMap("UnitRadius=1");
-        AstCmpMap *inner = astCmpMap(sm, s2, 1, "");
-        AstCmpMap *outer = astCmpMap(s1, inner, 1, "");
+        AstCmpMap *inner = astCmpMap(sm, s2, 1, " ");
+        AstCmpMap *outer = astCmpMap(s1, inner, 1, " ");
         write_negative_fixture(dir, "neg_sph_sandwich_wrong_middle", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         s1 = astAnnul(s1); sm = astAnnul(sm); s2 = astAnnul(s2);
@@ -2314,10 +2314,10 @@ static void gen_negative_fixtures_7(const char *dir) {
         double diag[] = {1.0, 2.0, 3.0};
         AstSphMap *s1 = astSphMap("UnitRadius=1");
         astInvert(s1);
-        AstMatrixMap *mm = astMatrixMap(3, 3, 1, diag, "");
+        AstMatrixMap *mm = astMatrixMap(3, 3, 1, diag, " ");
         AstSphMap *s2 = astSphMap("UnitRadius=1");
-        AstCmpMap *inner = astCmpMap(mm, s2, 1, "");
-        AstCmpMap *outer = astCmpMap(s1, inner, 1, "");
+        AstCmpMap *inner = astCmpMap(mm, s2, 1, " ");
+        AstCmpMap *outer = astCmpMap(s1, inner, 1, " ");
         write_negative_fixture(dir, "neg_sph_sandwich_unequal_diag", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         s1 = astAnnul(s1); mm = astAnnul(mm); s2 = astAnnul(s2);
@@ -2328,12 +2328,12 @@ static void gen_negative_fixtures_7(const char *dir) {
         if (!astOK) astClearStatus;
         double cen[] = {0.0, 0.0};
         double shifts[] = {1.0, 2.0};
-        AstPcdMap *p1 = astPcdMap(0.001, cen, "");
-        AstShiftMap *sm = astShiftMap(2, shifts, "");
-        AstPcdMap *p2 = astPcdMap(0.001, cen, "");
+        AstPcdMap *p1 = astPcdMap(0.001, cen, " ");
+        AstShiftMap *sm = astShiftMap(2, shifts, " ");
+        AstPcdMap *p2 = astPcdMap(0.001, cen, " ");
         astInvert(p2);
-        AstCmpMap *inner = astCmpMap(sm, p2, 1, "");
-        AstCmpMap *outer = astCmpMap(p1, inner, 1, "");
+        AstCmpMap *inner = astCmpMap(sm, p2, 1, " ");
+        AstCmpMap *outer = astCmpMap(p1, inner, 1, " ");
         write_negative_fixture(dir, "neg_pcd_nonswappable_between", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         p1 = astAnnul(p1); sm = astAnnul(sm); p2 = astAnnul(p2);
@@ -2346,12 +2346,12 @@ static void gen_negative_fixtures_7(const char *dir) {
         if (!astOK) astClearStatus;
         const char *fwd[] = {"y1 = x1", "y2 = x2"};
         const char *inv[] = {"x1 = y1", "x2 = y2"};
-        AstWcsMap *w1 = astWcsMap(2, AST__TAN, 1, 2, "");
-        AstMathMap *mm = astMathMap(2, 2, 2, fwd, 2, inv, "");
-        AstWcsMap *w2 = astWcsMap(2, AST__TAN, 1, 2, "");
+        AstWcsMap *w1 = astWcsMap(2, AST__TAN, 1, 2, " ");
+        AstMathMap *mm = astMathMap(2, 2, 2, fwd, 2, inv, " ");
+        AstWcsMap *w2 = astWcsMap(2, AST__TAN, 1, 2, " ");
         astInvert(w2);
-        AstCmpMap *inner = astCmpMap(mm, w2, 1, "");
-        AstCmpMap *outer = astCmpMap(w1, inner, 1, "");
+        AstCmpMap *inner = astCmpMap(mm, w2, 1, " ");
+        AstCmpMap *outer = astCmpMap(w1, inner, 1, " ");
         write_negative_fixture(dir, "neg_wcs_nonperm_between", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         w1 = astAnnul(w1); mm = astAnnul(mm); w2 = astAnnul(w2);
@@ -2368,8 +2368,8 @@ static void gen_negative_fixtures_8(const char *dir) {
     {
         if (!astOK) astClearStatus;
         AstSphMap *sm = astSphMap("UnitRadius=1");
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstCmpMap *cm = astCmpMap(sm, zm, 0, "");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(sm, zm, 0, " ");
         write_negative_fixture(dir, "neg_sph_parallel", (AstMapping*)cm);
         cm = astAnnul(cm); sm = astAnnul(sm); zm = astAnnul(zm);
     }
@@ -2380,10 +2380,10 @@ static void gen_negative_fixtures_8(const char *dir) {
         double mat[] = {1.0, 0.5, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
         AstSphMap *s1 = astSphMap("UnitRadius=1");
         astInvert(s1);
-        AstMatrixMap *mm = astMatrixMap(3, 3, 0, mat, "");
+        AstMatrixMap *mm = astMatrixMap(3, 3, 0, mat, " ");
         AstSphMap *s2 = astSphMap("UnitRadius=1");
-        AstCmpMap *inner = astCmpMap(mm, s2, 1, "");
-        AstCmpMap *outer = astCmpMap(s1, inner, 1, "");
+        AstCmpMap *inner = astCmpMap(mm, s2, 1, " ");
+        AstCmpMap *outer = astCmpMap(s1, inner, 1, " ");
         write_negative_fixture(dir, "neg_sph_sandwich_full_matrix", (AstMapping*)outer);
         outer = astAnnul(outer); inner = astAnnul(inner);
         s1 = astAnnul(s1); mm = astAnnul(mm); s2 = astAnnul(s2);
@@ -2392,10 +2392,10 @@ static void gen_negative_fixtures_8(const char *dir) {
     /* normmap-08: NormMap followed by non-NormMap — no cancel */
     {
         if (!astOK) astClearStatus;
-        AstSkyFrame *sf = astSkyFrame("");
-        AstNormMap *nm = astNormMap(sf, "");
-        AstZoomMap *zm = astZoomMap(2, 2.0, "");
-        AstCmpMap *cm = astCmpMap(nm, zm, 1, "");
+        AstSkyFrame *sf = astSkyFrame(" ");
+        AstNormMap *nm = astNormMap(sf, " ");
+        AstZoomMap *zm = astZoomMap(2, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(nm, zm, 1, " ");
         write_negative_fixture(dir, "neg_normmap_nonnorm_neighbour", (AstMapping*)cm);
         cm = astAnnul(cm); nm = astAnnul(nm); zm = astAnnul(zm);
         sf = astAnnul(sf);
@@ -2404,9 +2404,9 @@ static void gen_negative_fixtures_8(const char *dir) {
     /* grismmap-11: ZoomMap before forward (non-inverted) GrismMap — wrong config */
     {
         if (!astOK) astClearStatus;
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstGrismMap *gm = astGrismMap("");
-        AstCmpMap *cm = astCmpMap(zm, gm, 1, "");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstGrismMap *gm = astGrismMap(" ");
+        AstCmpMap *cm = astCmpMap(zm, gm, 1, " ");
         write_negative_fixture(dir, "neg_grism_zoom_before_fwd", (AstMapping*)cm);
         cm = astAnnul(cm); zm = astAnnul(zm); gm = astAnnul(gm);
     }
@@ -2415,10 +2415,10 @@ static void gen_negative_fixtures_8(const char *dir) {
     {
         if (!astOK) astClearStatus;
         double shifts[] = {1.0};
-        AstShiftMap *sm = astShiftMap(1, shifts, "");
-        AstGrismMap *gm = astGrismMap("");
+        AstShiftMap *sm = astShiftMap(1, shifts, " ");
+        AstGrismMap *gm = astGrismMap(" ");
         astInvert(gm);
-        AstCmpMap *cm = astCmpMap(sm, gm, 1, "");
+        AstCmpMap *cm = astCmpMap(sm, gm, 1, " ");
         write_negative_fixture(dir, "neg_grism_nonzoom_before_inv", (AstMapping*)cm);
         cm = astAnnul(cm); sm = astAnnul(sm); gm = astAnnul(gm);
     }
@@ -2428,9 +2428,9 @@ static void gen_negative_fixtures_8(const char *dir) {
     {
         if (!astOK) astClearStatus;
         double centre[] = {1.0, 2.0};
-        AstUnitNormMap *unm = astUnitNormMap(2, centre, "");
-        AstZoomMap *zm = astZoomMap(3, 2.0, "");
-        AstCmpMap *cm = astCmpMap(unm, zm, 1, "");
+        AstUnitNormMap *unm = astUnitNormMap(2, centre, " ");
+        AstZoomMap *zm = astZoomMap(3, 2.0, " ");
+        AstCmpMap *cm = astCmpMap(unm, zm, 1, " ");
         write_negative_fixture(dir, "neg_unitnormmap_nonmergeable", (AstMapping*)cm);
         cm = astAnnul(cm); unm = astAnnul(unm); zm = astAnnul(zm);
     }
@@ -2455,15 +2455,15 @@ static void gen_cascade_positives_2(const char *dir) {
         const char *inv2[] = {"x = y/3"};
         AstMathMap *ma1 = astMathMap(1, 1, 1, fwd1, 1, inv1, "SimpFI=1,SimpIF=1");
         AstMathMap *mb1 = astMathMap(1, 1, 1, fwd2, 1, inv2, "SimpFI=1,SimpIF=1");
-        AstCmpMap *par1 = astCmpMap(ma1, mb1, 0, "");
+        AstCmpMap *par1 = astCmpMap(ma1, mb1, 0, " ");
 
         AstMathMap *ma2 = astMathMap(1, 1, 1, fwd1, 1, inv1, "SimpFI=1,SimpIF=1");
         AstMathMap *mb2 = astMathMap(1, 1, 1, fwd2, 1, inv2, "SimpFI=1,SimpIF=1");
         astInvert(ma2);
         astInvert(mb2);
-        AstCmpMap *par2 = astCmpMap(ma2, mb2, 0, "");
+        AstCmpMap *par2 = astCmpMap(ma2, mb2, 0, " ");
 
-        AstCmpMap *cm = astCmpMap(par1, par2, 1, "");
+        AstCmpMap *cm = astCmpMap(par1, par2, 1, " ");
         write_fixture(dir, "cmpmap_parallel_in_series_merge", (AstMapping*)cm);
         cm = astAnnul(cm); par1 = astAnnul(par1); par2 = astAnnul(par2);
         ma1 = astAnnul(ma1); mb1 = astAnnul(mb1);
@@ -2482,15 +2482,15 @@ static void gen_cascade_positives_2(const char *dir) {
         const char *inv1[] = {"x = 0.25*y"};
         AstMathMap *m2d_a = astMathMap(2, 2, 2, fwd2, 2, inv2, "SimpFI=1,SimpIF=1");
         AstMathMap *m1d_a = astMathMap(1, 1, 1, fwd1, 1, inv1, "SimpFI=1,SimpIF=1");
-        AstCmpMap *par1 = astCmpMap(m2d_a, m1d_a, 0, "");
+        AstCmpMap *par1 = astCmpMap(m2d_a, m1d_a, 0, " ");
 
         AstMathMap *m1d_b = astMathMap(1, 1, 1, fwd1, 1, inv1, "SimpFI=1,SimpIF=1");
         AstMathMap *m2d_b = astMathMap(2, 2, 2, fwd2, 2, inv2, "SimpFI=1,SimpIF=1");
         astInvert(m1d_b);
         astInvert(m2d_b);
-        AstCmpMap *par2 = astCmpMap(m1d_b, m2d_b, 0, "");
+        AstCmpMap *par2 = astCmpMap(m1d_b, m2d_b, 0, " ");
 
-        AstCmpMap *cm = astCmpMap(par1, par2, 1, "");
+        AstCmpMap *cm = astCmpMap(par1, par2, 1, " ");
         write_fixture(dir, "cmpmap_parallel_series_dim_mismatch", (AstMapping*)cm);
         cm = astAnnul(cm); par1 = astAnnul(par1); par2 = astAnnul(par2);
         m2d_a = astAnnul(m2d_a); m1d_a = astAnnul(m1d_a);
@@ -2510,11 +2510,11 @@ static void gen_cascade_positives_2(const char *dir) {
         const char *inva[] = {"x = 0.5*y"};
         const char *fwdb[] = {"y = 3*x"};
         const char *invb[] = {"x = y/3"};
-        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, consts, "");
-        AstMathMap *ma = astMathMap(1, 1, 1, fwda, 1, inva, "");
-        AstMathMap *mb = astMathMap(1, 1, 1, fwdb, 1, invb, "");
-        AstCmpMap *par = astCmpMap(ma, mb, 0, "");
-        AstCmpMap *cm = astCmpMap(pm, par, 1, "");
+        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, consts, " ");
+        AstMathMap *ma = astMathMap(1, 1, 1, fwda, 1, inva, " ");
+        AstMathMap *mb = astMathMap(1, 1, 1, fwdb, 1, invb, " ");
+        AstCmpMap *par = astCmpMap(ma, mb, 0, " ");
+        AstCmpMap *cm = astCmpMap(pm, par, 1, " ");
         write_fixture(dir, "cmpmap_perm_swap_aconstants", (AstMapping*)cm);
         cm = astAnnul(cm); pm = astAnnul(pm); par = astAnnul(par);
         ma = astAnnul(ma); mb = astAnnul(mb);
@@ -2533,11 +2533,11 @@ static void gen_cascade_positives_2(const char *dir) {
         const char *inva[] = {"x = 0.5*y"};
         const char *fwdb[] = {"y = 3*x"};
         const char *invb[] = {"x = y/3"};
-        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, consts, "");
-        AstMathMap *ma = astMathMap(1, 1, 1, fwda, 1, inva, "");
-        AstMathMap *mb = astMathMap(1, 1, 1, fwdb, 1, invb, "");
-        AstCmpMap *par = astCmpMap(ma, mb, 0, "");
-        AstCmpMap *cm = astCmpMap(pm, par, 1, "");
+        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, consts, " ");
+        AstMathMap *ma = astMathMap(1, 1, 1, fwda, 1, inva, " ");
+        AstMathMap *mb = astMathMap(1, 1, 1, fwdb, 1, invb, " ");
+        AstCmpMap *par = astCmpMap(ma, mb, 0, " ");
+        AstCmpMap *cm = astCmpMap(pm, par, 1, " ");
         write_fixture(dir, "cmpmap_perm_swap_bconstants", (AstMapping*)cm);
         cm = astAnnul(cm); pm = astAnnul(pm); par = astAnnul(par);
         ma = astAnnul(ma); mb = astAnnul(mb);
@@ -2549,15 +2549,15 @@ static void gen_cascade_positives_2(const char *dir) {
         if (!astOK) astClearStatus;
         AstFrame *base = astFrame(2, "Domain=PIXEL");
         AstFrame *curr = astFrame(2, "Domain=ZOOMED");
-        AstZoomMap *z1 = astZoomMap(2, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(2, 3.0, "");
-        AstCmpMap *map = astCmpMap(z1, z2, 1, "");
-        AstFrameSet *fs = astFrameSet(base, "");
+        AstZoomMap *z1 = astZoomMap(2, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(2, 3.0, " ");
+        AstCmpMap *map = astCmpMap(z1, z2, 1, " ");
+        AstFrameSet *fs = astFrameSet(base, " ");
         astAddFrame(fs, AST__BASE, map, curr);
         double lbnd[] = {0.0, 0.0};
         double ubnd[] = {10.0, 10.0};
-        AstBox *box = astBox(fs, 1, lbnd, ubnd, NULL, "");
-        AstNormMap *nm = astNormMap((AstFrame *)box, "");
+        AstBox *box = astBox(fs, 1, lbnd, ubnd, NULL, " ");
+        AstNormMap *nm = astNormMap((AstFrame *)box, " ");
         write_fixture(dir, "normmap_frame_simplifies", (AstMapping*)nm);
         nm = astAnnul(nm); box = astAnnul(box); fs = astAnnul(fs);
         map = astAnnul(map); base = astAnnul(base); curr = astAnnul(curr);
@@ -2568,11 +2568,11 @@ static void gen_cascade_positives_2(const char *dir) {
        NormMap(forward) + Inverse(NormMap) with same Frame. */
     {
         if (!astOK) astClearStatus;
-        AstSkyFrame *sf = astSkyFrame("");
-        AstNormMap *n1 = astNormMap(sf, "");
-        AstNormMap *n2 = astNormMap(sf, "");
+        AstSkyFrame *sf = astSkyFrame(" ");
+        AstNormMap *n1 = astNormMap(sf, " ");
+        AstNormMap *n2 = astNormMap(sf, " ");
         astInvert(n2);
-        AstCmpMap *cm = astCmpMap(n1, n2, 1, "");
+        AstCmpMap *cm = astCmpMap(n1, n2, 1, " ");
         write_fixture(dir, "normmap_inverse_cancel_upper", (AstMapping*)cm);
         cm = astAnnul(cm); n1 = astAnnul(n1); n2 = astAnnul(n2);
         sf = astAnnul(sf);
@@ -2584,10 +2584,10 @@ static void gen_cascade_positives_2(const char *dir) {
         if (!astOK) astClearStatus;
         const char *fwd[] = {"y = 2*x"};
         const char *inv[] = {"x = 0.5*y"};
-        AstMathMap *mm = astMathMap(1, 1, 1, fwd, 1, inv, "");
-        AstUnitMap *um = astUnitMap(1, "");
+        AstMathMap *mm = astMathMap(1, 1, 1, fwd, 1, inv, " ");
+        AstUnitMap *um = astUnitMap(1, " ");
         astInvert(um);
-        AstCmpMap *cm = astCmpMap(mm, um, 0, "");
+        AstCmpMap *cm = astCmpMap(mm, um, 0, " ");
         write_fixture(dir, "unit_parallel_invert_clear", (AstMapping*)cm);
         cm = astAnnul(cm); mm = astAnnul(mm); um = astAnnul(um);
     }
@@ -2600,9 +2600,9 @@ static void gen_cascade_positives_2(const char *dir) {
         int inperm[] = {1, -1};
         int outperm[] = {1, 2};
         double consts[] = {42.0};
-        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, consts, "");
-        AstUnitMap *um = astUnitMap(2, "");
-        AstCmpMap *cm = astCmpMap(um, pm, 1, "");
+        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, consts, " ");
+        AstUnitMap *um = astUnitMap(2, " ");
+        AstCmpMap *cm = astCmpMap(um, pm, 1, " ");
         write_fixture(dir, "perm_inperm_constant_fold", (AstMapping*)cm);
         cm = astAnnul(cm); pm = astAnnul(pm); um = astAnnul(um);
     }
@@ -2615,9 +2615,9 @@ static void gen_cascade_positives_2(const char *dir) {
         int inperm[] = {1, 2};
         int outperm[] = {1, -1};
         double consts[] = {42.0};
-        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, consts, "");
-        AstUnitMap *um = astUnitMap(2, "");
-        AstCmpMap *cm = astCmpMap(pm, um, 1, "");
+        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, consts, " ");
+        AstUnitMap *um = astUnitMap(2, " ");
+        AstCmpMap *cm = astCmpMap(pm, um, 1, " ");
         write_fixture(dir, "perm_outperm_constant_fold", (AstMapping*)cm);
         cm = astAnnul(cm); pm = astAnnul(pm); um = astAnnul(um);
     }
@@ -2628,11 +2628,11 @@ static void gen_cascade_positives_2(const char *dir) {
         if (!astOK) astClearStatus;
         int in1[] = {1, 2};
         int out1[] = {1, 0};
-        AstPermMap *p1 = astPermMap(2, in1, 2, out1, NULL, "");
+        AstPermMap *p1 = astPermMap(2, in1, 2, out1, NULL, " ");
         int in2[] = {1, 2};
         int out2[] = {2, 1};
-        AstPermMap *p2 = astPermMap(2, in2, 2, out2, NULL, "");
-        AstCmpMap *cm = astCmpMap(p1, p2, 1, "");
+        AstPermMap *p2 = astPermMap(2, in2, 2, out2, NULL, " ");
+        AstCmpMap *cm = astCmpMap(p1, p2, 1, " ");
         write_fixture(dir, "perm_bad_propagation", (AstMapping*)cm);
         cm = astAnnul(cm); p1 = astAnnul(p1); p2 = astAnnul(p2);
     }
@@ -2650,13 +2650,13 @@ static void gen_cascade_positives_2(const char *dir) {
         const char *i3[] = {"x = 0.25*y"};
         const char *f4[] = {"y = 5*x"};
         const char *i4[] = {"x = 0.2*y"};
-        AstMathMap *m1 = astMathMap(1, 1, 1, f1, 1, i1, "");
-        AstMathMap *m2 = astMathMap(1, 1, 1, f2, 1, i2, "");
-        AstMathMap *m3 = astMathMap(1, 1, 1, f3, 1, i3, "");
-        AstCmpMap *inner = astCmpMap(m2, m3, 0, "");
-        AstCmpMap *left = astCmpMap(m1, inner, 0, "");
-        AstMathMap *m4 = astMathMap(1, 1, 1, f4, 1, i4, "");
-        AstCmpMap *outer = astCmpMap(left, m4, 0, "");
+        AstMathMap *m1 = astMathMap(1, 1, 1, f1, 1, i1, " ");
+        AstMathMap *m2 = astMathMap(1, 1, 1, f2, 1, i2, " ");
+        AstMathMap *m3 = astMathMap(1, 1, 1, f3, 1, i3, " ");
+        AstCmpMap *inner = astCmpMap(m2, m3, 0, " ");
+        AstCmpMap *left = astCmpMap(m1, inner, 0, " ");
+        AstMathMap *m4 = astMathMap(1, 1, 1, f4, 1, i4, " ");
+        AstCmpMap *outer = astCmpMap(left, m4, 0, " ");
         write_fixture(dir, "cmpmap_decompose_middle", (AstMapping*)outer);
         outer = astAnnul(outer); left = astAnnul(left);
         inner = astAnnul(inner);
@@ -2673,14 +2673,14 @@ static void gen_cascade_positives_2(const char *dir) {
         const char *inv[] = {"x = 0.5*y"};
         AstMathMap *m1a = astMathMap(1, 1, 1, fwd, 1, inv, "SimpFI=1,SimpIF=1");
         AstMathMap *m1b = astMathMap(1, 1, 1, fwd, 1, inv, "SimpFI=1,SimpIF=1");
-        AstCmpMap *ser1 = astCmpMap(m1a, m1b, 1, "");
+        AstCmpMap *ser1 = astCmpMap(m1a, m1b, 1, " ");
         astInvert(ser1);
 
         AstMathMap *m2a = astMathMap(1, 1, 1, fwd, 1, inv, "SimpFI=1,SimpIF=1");
         AstMathMap *m2b = astMathMap(1, 1, 1, fwd, 1, inv, "SimpFI=1,SimpIF=1");
-        AstCmpMap *ser2 = astCmpMap(m2a, m2b, 1, "");
+        AstCmpMap *ser2 = astCmpMap(m2a, m2b, 1, " ");
 
-        AstCmpMap *par = astCmpMap(ser1, ser2, 0, "");
+        AstCmpMap *par = astCmpMap(ser1, ser2, 0, " ");
         write_fixture(dir, "cmpmap_series_in_parallel_inverted", (AstMapping*)par);
         par = astAnnul(par); ser1 = astAnnul(ser1); ser2 = astAnnul(ser2);
         m1a = astAnnul(m1a); m1b = astAnnul(m1b);
@@ -2693,13 +2693,13 @@ static void gen_cascade_positives_2(const char *dir) {
         if (!astOK) astClearStatus;
         double ina[] = {0, 0}, inb[] = {1, 1};
         double outa[] = {1, 2}, outb[] = {3, 5};
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
         double shifts1[] = {1.0};
         double shifts2[] = {2.0};
-        AstShiftMap *sm1 = astShiftMap(1, shifts1, "");
-        AstShiftMap *sm2 = astShiftMap(1, shifts2, "");
-        AstCmpMap *par = astCmpMap(sm1, sm2, 0, "");
-        AstCmpMap *cm = astCmpMap(wm, par, 1, "");
+        AstShiftMap *sm1 = astShiftMap(1, shifts1, " ");
+        AstShiftMap *sm2 = astShiftMap(1, shifts2, " ");
+        AstCmpMap *par = astCmpMap(sm1, sm2, 0, " ");
+        AstCmpMap *cm = astCmpMap(wm, par, 1, " ");
         write_fixture(dir, "win_upper_cmpmap_parallel_merge", (AstMapping*)cm);
         cm = astAnnul(cm); wm = astAnnul(wm); par = astAnnul(par);
         sm1 = astAnnul(sm1); sm2 = astAnnul(sm2);
@@ -2713,11 +2713,11 @@ static void gen_cascade_positives_2(const char *dir) {
         int in1[] = {1, -1};
         int out1[] = {1, 2};
         double c1[] = {42.0};
-        AstPermMap *p1 = astPermMap(2, in1, 2, out1, c1, "");
+        AstPermMap *p1 = astPermMap(2, in1, 2, out1, c1, " ");
         int in2[] = {2, 1};
         int out2[] = {2, 1};
-        AstPermMap *p2 = astPermMap(2, in2, 2, out2, NULL, "");
-        AstCmpMap *cm = astCmpMap(p1, p2, 1, "");
+        AstPermMap *p2 = astPermMap(2, in2, 2, out2, NULL, " ");
+        AstCmpMap *cm = astCmpMap(p1, p2, 1, " ");
         write_fixture(dir, "perm_constant_propagation", (AstMapping*)cm);
         cm = astAnnul(cm); p1 = astAnnul(p1); p2 = astAnnul(p2);
     }
@@ -2728,9 +2728,9 @@ static void gen_cascade_positives_2(const char *dir) {
         double centre[] = {1.0, 2.0};
         double ina[] = {0, 0}, inb[] = {1, 1};
         double outa[] = {0.5, 0.5}, outb[] = {1.5, 1.5};
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstUnitNormMap *unm = astUnitNormMap(2, centre, "");
-        AstCmpMap *cm = astCmpMap(wm, unm, 1, "");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstUnitNormMap *unm = astUnitNormMap(2, centre, " ");
+        AstCmpMap *cm = astCmpMap(wm, unm, 1, " ");
         write_fixture(dir, "unitnormmap_winmap_fwd_merge", (AstMapping*)cm);
         cm = astAnnul(cm); wm = astAnnul(wm); unm = astAnnul(unm);
     }
@@ -2742,10 +2742,10 @@ static void gen_cascade_positives_2(const char *dir) {
         double centre[] = {1.0, 2.0};
         double ina[] = {0, 0}, inb[] = {1, 1};
         double outa[] = {0.5, 0.5}, outb[] = {1.5, 1.5};
-        AstUnitNormMap *unm = astUnitNormMap(2, centre, "");
+        AstUnitNormMap *unm = astUnitNormMap(2, centre, " ");
         astInvert(unm);
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
-        AstCmpMap *cm = astCmpMap(unm, wm, 1, "");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
+        AstCmpMap *cm = astCmpMap(unm, wm, 1, " ");
         write_fixture(dir, "unitnormmap_inv_winmap_merge", (AstMapping*)cm);
         cm = astAnnul(cm); unm = astAnnul(unm); wm = astAnnul(wm);
     }
@@ -2767,9 +2767,9 @@ static void gen_cascade_positives_3(const char *dir) {
         int inperm[] = {-1, -2, 1};
         int outperm[] = {3};
         double consts[] = {0.5, 0.5};
-        AstWcsMap *wm = astWcsMap(3, AST__TAN, 1, 2, "");
-        AstPermMap *pm = astPermMap(3, inperm, 1, outperm, consts, "");
-        AstCmpMap *cm = astCmpMap(wm, pm, 1, "");
+        AstWcsMap *wm = astWcsMap(3, AST__TAN, 1, 2, " ");
+        AstPermMap *pm = astPermMap(3, inperm, 1, outperm, consts, " ");
+        AstCmpMap *cm = astCmpMap(wm, pm, 1, " ");
         write_fixture(dir, "wcsmap_perm_swap_simplify", (AstMapping*)cm);
         cm = astAnnul(cm); wm = astAnnul(wm); pm = astAnnul(pm);
     }
@@ -2783,9 +2783,9 @@ static void gen_cascade_positives_3(const char *dir) {
         int inperm[] = {1, 2, -1};
         int outperm[] = {1, 2, 0};
         double consts[] = {42.0};
-        AstPermMap *pm = astPermMap(3, inperm, 3, outperm, consts, "");
-        AstUnitMap *um = astUnitMap(3, "");
-        AstCmpMap *cm = astCmpMap(pm, um, 1, "");
+        AstPermMap *pm = astPermMap(3, inperm, 3, outperm, consts, " ");
+        AstUnitMap *um = astUnitMap(3, " ");
+        AstCmpMap *cm = astCmpMap(pm, um, 1, " ");
         write_fixture(dir, "perm_array_simplify", (AstMapping*)cm);
         cm = astAnnul(cm); pm = astAnnul(pm); um = astAnnul(um);
     }
@@ -2797,9 +2797,9 @@ static void gen_cascade_positives_3(const char *dir) {
         if (!astOK) astClearStatus;
         int inperm[] = {2, 1};
         int outperm[] = {1, 2};
-        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, NULL, "");
-        AstUnitMap *um = astUnitMap(2, "");
-        AstCmpMap *cm = astCmpMap(pm, um, 1, "");
+        AstPermMap *pm = astPermMap(2, inperm, 2, outperm, NULL, " ");
+        AstUnitMap *um = astUnitMap(2, " ");
+        AstCmpMap *cm = astCmpMap(pm, um, 1, " ");
         write_fixture(dir, "perm_identity_array_null", (AstMapping*)cm);
         cm = astAnnul(cm); pm = astAnnul(pm); um = astAnnul(um);
     }
@@ -2816,7 +2816,7 @@ static void gen_negative_fixtures_9(const char *dir) {
         if (!astOK) astClearStatus;
         double ina[] = {0, 0}, inb[] = {1, 1};
         double outa[] = {1, 2}, outb[] = {4, 6};
-        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, "");
+        AstWinMap *wm = astWinMap(2, ina, inb, outa, outb, " ");
         write_negative_fixture(dir, "neg_win_mixed_no_selfsimplify", (AstMapping*)wm);
         wm = astAnnul(wm);
     }
@@ -2824,10 +2824,10 @@ static void gen_negative_fixtures_9(const char *dir) {
     /* ratemap-04: RateMaps in parallel — refuses */
     {
         if (!astOK) astClearStatus;
-        AstZoomMap *zm = astZoomMap(1, 2.0, "");
-        AstRateMap *r1 = astRateMap(zm, 1, 1, "");
-        AstRateMap *r2 = astRateMap(zm, 1, 1, "");
-        AstCmpMap *cm = astCmpMap(r1, r2, 0, "");
+        AstZoomMap *zm = astZoomMap(1, 2.0, " ");
+        AstRateMap *r1 = astRateMap(zm, 1, 1, " ");
+        AstRateMap *r2 = astRateMap(zm, 1, 1, " ");
+        AstCmpMap *cm = astCmpMap(r1, r2, 0, " ");
         write_negative_fixture(dir, "neg_ratemap_parallel", (AstMapping*)cm);
         cm = astAnnul(cm); r1 = astAnnul(r1); r2 = astAnnul(r2);
         zm = astAnnul(zm);
@@ -2838,7 +2838,7 @@ static void gen_negative_fixtures_9(const char *dir) {
         if (!astOK) astClearStatus;
         double args1[] = {53000.0, 0.5, -2.5, 6378.0, 0.0, 0.0, 0.0};
         double args2[] = {53000.0, 0.5, -2.6, 6378.0, 0.0, 0.0, 0.0};
-        AstTimeMap *tm = astTimeMap(0, "");
+        AstTimeMap *tm = astTimeMap(0, " ");
         astTimeAdd(tm, "TTTOTDB", 5, args1);
         astTimeAdd(tm, "TDBTOTT", 5, args2);
         write_negative_fixture(dir, "neg_time_5arg_mismatch", (AstMapping*)tm);
@@ -2850,7 +2850,7 @@ static void gen_negative_fixtures_9(const char *dir) {
         if (!astOK) astClearStatus;
         double args1[] = {-2.5, 0.9, 1000.0, 51544.0, 0.5, 1.2, 0.0};
         double args2[] = {-2.5, 0.9, 1000.0, 51544.0, 0.5, 1.3, 0.0};
-        AstSpecMap *sm = astSpecMap(1, 0, "");
+        AstSpecMap *sm = astSpecMap(1, 0, " ");
         astSpecAdd(sm, "TPF2HL", 6, args1);
         astSpecAdd(sm, "HLF2TP", 6, args2);
         write_negative_fixture(dir, "neg_spec_6arg_mismatch", (AstMapping*)sm);
@@ -2862,7 +2862,7 @@ static void gen_negative_fixtures_9(const char *dir) {
         if (!astOK) astClearStatus;
         double args1[] = {51544.0, 0.5, 1.2, 150.0e6};
         double args2[] = {51544.0, 0.5, 1.2, 151.0e6};
-        AstSlaMap *sm = astSlaMap(0, "");
+        AstSlaMap *sm = astSlaMap(0, " ");
         astSlaAdd(sm, "HPCEQ", 4, args1);
         astSlaAdd(sm, "EQHPC", 4, args2);
         write_negative_fixture(dir, "neg_sla_4arg_mismatch", (AstMapping*)sm);
@@ -2873,7 +2873,7 @@ static void gen_negative_fixtures_9(const char *dir) {
     {
         if (!astOK) astClearStatus;
         double coeff_i[] = {1.0, 1, 1};
-        AstPolyMap *pm = astPolyMap(1, 1, 0, NULL, 1, coeff_i, "");
+        AstPolyMap *pm = astPolyMap(1, 1, 0, NULL, 1, coeff_i, " ");
         write_negative_fixture(dir, "neg_poly_no_forward", (AstMapping*)pm);
         pm = astAnnul(pm);
     }
@@ -2884,10 +2884,10 @@ static void gen_negative_fixtures_9(const char *dir) {
         double tx[] = {0, 1}, ty[] = {0, 1};
         double cu1[] = {1.5}, cv1[] = {2.5};
         double cu2[] = {3.0}, cv2[] = {4.0};
-        AstSplineMap *s1 = astSplineMap(1, 1, 1, 1, tx, ty, cu1, cv1, "");
-        AstSplineMap *s2 = astSplineMap(1, 1, 1, 1, tx, ty, cu2, cv2, "");
+        AstSplineMap *s1 = astSplineMap(1, 1, 1, 1, tx, ty, cu1, cv1, " ");
+        AstSplineMap *s2 = astSplineMap(1, 1, 1, 1, tx, ty, cu2, cv2, " ");
         astInvert(s2);
-        AstCmpMap *cm = astCmpMap(s1, s2, 1, "");
+        AstCmpMap *cm = astCmpMap(s1, s2, 1, " ");
         write_negative_fixture(dir, "neg_spline_different_coeffs", (AstMapping*)cm);
         cm = astAnnul(cm); s1 = astAnnul(s1); s2 = astAnnul(s2);
     }
@@ -2904,13 +2904,13 @@ static void gen_region_fixtures(const char *dir) {
        an unsimplified internal FrameSet. astSimplify then reduces it. */
     {
         if (!astOK) astClearStatus;
-        AstFrame *f = astFrame(2, "");
+        AstFrame *f = astFrame(2, " ");
         double lbnd[] = {0.0, 0.0};
         double ubnd[] = {10.0, 10.0};
-        AstBox *box = astBox(f, 1, lbnd, ubnd, NULL, "");
-        AstZoomMap *z1 = astZoomMap(2, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(2, 3.0, "");
-        AstCmpMap *map = astCmpMap(z1, z2, 1, "");
+        AstBox *box = astBox(f, 1, lbnd, ubnd, NULL, " ");
+        AstZoomMap *z1 = astZoomMap(2, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(2, 3.0, " ");
+        AstCmpMap *map = astCmpMap(z1, z2, 1, " ");
         AstFrame *f2 = astFrame(2, "Domain=ZOOMED");
         AstRegion *mapped = astMapRegion(box, map, f2);
         write_fixture(dir, "box_self_simplify", (AstMapping*)mapped);
@@ -2923,13 +2923,13 @@ static void gen_region_fixtures(const char *dir) {
        merge into a 2D Box. */
     {
         if (!astOK) astClearStatus;
-        AstFrame *f1 = astFrame(1, "");
+        AstFrame *f1 = astFrame(1, " ");
         double lb1[] = {0.0}, ub1[] = {10.0};
-        AstBox *b1 = astBox(f1, 1, lb1, ub1, NULL, "");
-        AstFrame *f2 = astFrame(1, "");
+        AstBox *b1 = astBox(f1, 1, lb1, ub1, NULL, " ");
+        AstFrame *f2 = astFrame(1, " ");
         double lb2[] = {-5.0}, ub2[] = {5.0};
-        AstBox *b2 = astBox(f2, 1, lb2, ub2, NULL, "");
-        AstCmpMap *cm = astCmpMap(b1, b2, 0, "");
+        AstBox *b2 = astBox(f2, 1, lb2, ub2, NULL, " ");
+        AstCmpMap *cm = astCmpMap(b1, b2, 0, " ");
         write_fixture(dir, "box_parallel_merge", (AstMapping*)cm);
         cm = astAnnul(cm); b1 = astAnnul(b1); b2 = astAnnul(b2);
         f1 = astAnnul(f1); f2 = astAnnul(f2);
@@ -2940,14 +2940,14 @@ static void gen_region_fixtures(const char *dir) {
         if (!astOK) astClearStatus;
         AstFrame *base = astFrame(2, "Domain=PIXEL");
         AstFrame *curr = astFrame(2, "Domain=ZOOMED");
-        AstZoomMap *z1 = astZoomMap(2, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(2, 3.0, "");
-        AstCmpMap *map = astCmpMap(z1, z2, 1, "");
-        AstFrameSet *fs = astFrameSet(base, "");
+        AstZoomMap *z1 = astZoomMap(2, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(2, 3.0, " ");
+        AstCmpMap *map = astCmpMap(z1, z2, 1, " ");
+        AstFrameSet *fs = astFrameSet(base, " ");
         astAddFrame(fs, AST__BASE, map, curr);
         double lbnd[] = {0.0, 0.0};
         double ubnd[] = {10.0, 10.0};
-        AstInterval *intv = astInterval(fs, lbnd, ubnd, NULL, "");
+        AstInterval *intv = astInterval(fs, lbnd, ubnd, NULL, " ");
         write_fixture(dir, "interval_self_simplify", (AstMapping*)intv);
         intv = astAnnul(intv); fs = astAnnul(fs); map = astAnnul(map);
         base = astAnnul(base); curr = astAnnul(curr);
@@ -2957,13 +2957,13 @@ static void gen_region_fixtures(const char *dir) {
     /* interval-03/04: Interval parallel merge. */
     {
         if (!astOK) astClearStatus;
-        AstFrame *f1 = astFrame(1, "");
+        AstFrame *f1 = astFrame(1, " ");
         double lb1[] = {0.0}, ub1[] = {10.0};
-        AstInterval *i1 = astInterval(f1, lb1, ub1, NULL, "");
-        AstFrame *f2 = astFrame(1, "");
+        AstInterval *i1 = astInterval(f1, lb1, ub1, NULL, " ");
+        AstFrame *f2 = astFrame(1, " ");
         double lb2[] = {-5.0}, ub2[] = {5.0};
-        AstInterval *i2 = astInterval(f2, lb2, ub2, NULL, "");
-        AstCmpMap *cm = astCmpMap(i1, i2, 0, "");
+        AstInterval *i2 = astInterval(f2, lb2, ub2, NULL, " ");
+        AstCmpMap *cm = astCmpMap(i1, i2, 0, " ");
         write_fixture(dir, "interval_parallel_merge", (AstMapping*)cm);
         cm = astAnnul(cm); i1 = astAnnul(i1); i2 = astAnnul(i2);
         f1 = astAnnul(f1); f2 = astAnnul(f2);
@@ -2974,12 +2974,12 @@ static void gen_region_fixtures(const char *dir) {
         if (!astOK) astClearStatus;
         AstFrame *base = astFrame(2, "Domain=PIXEL");
         AstFrame *curr = astFrame(2, "Domain=ZOOMED");
-        AstZoomMap *z1 = astZoomMap(2, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(2, 3.0, "");
-        AstCmpMap *map = astCmpMap(z1, z2, 1, "");
-        AstFrameSet *fs = astFrameSet(base, "");
+        AstZoomMap *z1 = astZoomMap(2, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(2, 3.0, " ");
+        AstCmpMap *map = astCmpMap(z1, z2, 1, " ");
+        AstFrameSet *fs = astFrameSet(base, " ");
         astAddFrame(fs, AST__BASE, map, curr);
-        AstNullRegion *nr = astNullRegion(fs, NULL, "");
+        AstNullRegion *nr = astNullRegion(fs, NULL, " ");
         write_fixture(dir, "nullregion_self_simplify", (AstMapping*)nr);
         nr = astAnnul(nr); fs = astAnnul(fs); map = astAnnul(map);
         base = astAnnul(base); curr = astAnnul(curr);
@@ -2989,12 +2989,12 @@ static void gen_region_fixtures(const char *dir) {
     /* nullregion-03/04: NullRegion parallel merge. */
     {
         if (!astOK) astClearStatus;
-        AstFrame *f1 = astFrame(1, "");
-        AstNullRegion *n1 = astNullRegion(f1, NULL, "");
-        AstFrame *f2 = astFrame(1, "");
+        AstFrame *f1 = astFrame(1, " ");
+        AstNullRegion *n1 = astNullRegion(f1, NULL, " ");
+        AstFrame *f2 = astFrame(1, " ");
         double lb[] = {0.0}, ub[] = {10.0};
-        AstBox *b2 = astBox(f2, 1, lb, ub, NULL, "");
-        AstCmpMap *cm = astCmpMap(n1, b2, 0, "");
+        AstBox *b2 = astBox(f2, 1, lb, ub, NULL, " ");
+        AstCmpMap *cm = astCmpMap(n1, b2, 0, " ");
         write_fixture(dir, "nullregion_parallel_merge", (AstMapping*)cm);
         cm = astAnnul(cm); n1 = astAnnul(n1); b2 = astAnnul(b2);
         f1 = astAnnul(f1); f2 = astAnnul(f2);
@@ -3005,13 +3005,13 @@ static void gen_region_fixtures(const char *dir) {
         if (!astOK) astClearStatus;
         AstFrame *base = astFrame(2, "Domain=PIXEL");
         AstFrame *curr = astFrame(2, "Domain=ZOOMED");
-        AstZoomMap *z1 = astZoomMap(2, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(2, 3.0, "");
-        AstCmpMap *map = astCmpMap(z1, z2, 1, "");
-        AstFrameSet *fs = astFrameSet(base, "");
+        AstZoomMap *z1 = astZoomMap(2, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(2, 3.0, " ");
+        AstCmpMap *map = astCmpMap(z1, z2, 1, " ");
+        AstFrameSet *fs = astFrameSet(base, " ");
         astAddFrame(fs, AST__BASE, map, curr);
         double points[] = {1.0, 2.0, 3.0, 4.0};
-        AstPointList *pl = astPointList(fs, 2, 2, 2, points, NULL, "");
+        AstPointList *pl = astPointList(fs, 2, 2, 2, points, NULL, " ");
         write_fixture(dir, "pointlist_self_simplify", (AstMapping*)pl);
         pl = astAnnul(pl); fs = astAnnul(fs); map = astAnnul(map);
         base = astAnnul(base); curr = astAnnul(curr);
@@ -3023,16 +3023,16 @@ static void gen_region_fixtures(const char *dir) {
         if (!astOK) astClearStatus;
         AstFrame *base = astFrame(2, "Domain=PIXEL");
         AstFrame *curr = astFrame(2, "Domain=ZOOMED");
-        AstZoomMap *z1 = astZoomMap(2, 2.0, "");
-        AstZoomMap *z2 = astZoomMap(2, 3.0, "");
-        AstCmpMap *map = astCmpMap(z1, z2, 1, "");
-        AstFrameSet *fs = astFrameSet(base, "");
+        AstZoomMap *z1 = astZoomMap(2, 2.0, " ");
+        AstZoomMap *z2 = astZoomMap(2, 3.0, " ");
+        AstCmpMap *map = astCmpMap(z1, z2, 1, " ");
+        AstFrameSet *fs = astFrameSet(base, " ");
         astAddFrame(fs, AST__BASE, map, curr);
         double lbnd[] = {0.0, 0.0};
         double ubnd[] = {10.0, 10.0};
-        AstBox *box = astBox(fs, 1, lbnd, ubnd, NULL, "");
+        AstBox *box = astBox(fs, 1, lbnd, ubnd, NULL, " ");
         AstMapping *regs[] = {(AstMapping*)box};
-        AstSelectorMap *sm = astSelectorMap(1, (void**)regs, AST__BAD, "");
+        AstSelectorMap *sm = astSelectorMap(1, (void**)regs, AST__BAD, " ");
         write_fixture(dir, "selectormap_region_simplify", (AstMapping*)sm);
         sm = astAnnul(sm); box = astAnnul(box); fs = astAnnul(fs);
         map = astAnnul(map); base = astAnnul(base); curr = astAnnul(curr);

--- a/ast_tester/testfitschan.c
+++ b/ast_tester/testfitschan.c
@@ -2449,11 +2449,11 @@ int main( void ) {
          fexps[0] = "s = 1.4204e9 * exp( p * 1.0e-4 )";
          iexps[0] = "p = 1.0e4 * log( s / 1.4204e9 )";
          logmap = (AstMapping *)astMathMap( 1, 1, 1, fexps, 1, iexps,
-                                            " ", status );
+                                            " " );
          logspec = astSpecFrame( "System=FREQ,Unit=Hz,StdOfRest=Barycentric,"
-                                 "RestFreq=1.4204e9 Hz", status );
-         logpix = astFrame( 1, "Domain=GRID", status );
-         logtfs = astFrameSet( logpix, " ", status );
+                                 "RestFreq=1.4204e9 Hz" );
+         logpix = astFrame( 1, "Domain=GRID" );
+         logtfs = astFrameSet( logpix, " " );
          astAddFrame( logtfs, AST__BASE, logmap, (AstFrame *)logspec );
 
          logfc = astFitsChan( NULL, NULL, "Encoding=FITS-WCS" );
@@ -3337,7 +3337,7 @@ int main( void ) {
 
          if( rfs ) {
             /* Convert the current SkyFrame to the target system */
-            AstSkyFrame *tgt = astSkyFrame( " ", status );
+            AstSkyFrame *tgt = astSkyFrame( " " );
             astSetC( tgt, "System", sky_tests[it].system );
             AstFrameSet *cvt = astConvert( astGetFrame( rfs, AST__CURRENT ),
                                            (AstFrame *)tgt, "" );
@@ -3395,7 +3395,7 @@ int main( void ) {
       astClear( pfc, "Card" );
       AstFrameSet *pfs = (AstFrameSet *)astRead( pfc );
       if( pfs ) {
-         AstSkyFrame *gal = astSkyFrame( "System=Galactic", status );
+         AstSkyFrame *gal = astSkyFrame( "System=Galactic" );
          AstFrameSet *cvt = astConvert( astGetFrame( pfs, AST__CURRENT ),
                                         (AstFrame *)gal, "" );
          if( cvt ) {
@@ -3931,12 +3931,12 @@ int main( void ) {
       {
          AstSpecFrame *c1spec = astSpecFrame(
             "System=FREQ,Unit=Hz,StdOfRest=Source,"
-            "RefRA=3:00:00,RefDec=45:00:00", status );
+            "RefRA=3:00:00,RefDec=45:00:00" );
          astSetD( (AstFrame *)c1spec, "RestFreq", 1.420405752e9 );
          astSetD( (AstFrame *)c1spec, "Epoch", 52413.59 );
-         AstFrame *c1pix = astFrame( 1, "Domain=GRID", status );
-         AstMapping *c1map = (AstMapping *)astZoomMap( 1, 1.0e6, " ", status );
-         AstFrameSet *c1fs = astFrameSet( c1pix, " ", status );
+         AstFrame *c1pix = astFrame( 1, "Domain=GRID" );
+         AstMapping *c1map = (AstMapping *)astZoomMap( 1, 1.0e6, " " );
+         AstFrameSet *c1fs = astFrameSet( c1pix, " " );
          astAddFrame( c1fs, AST__BASE, c1map, (AstFrame *)c1spec );
 
          AstFitsChan *c1fc = astFitsChan( NULL, NULL, "Encoding=FITS-CLASS" );
@@ -3978,12 +3978,12 @@ int main( void ) {
       {
          AstSpecFrame *p1spec = astSpecFrame(
             "System=FREQ,Unit=Hz,StdOfRest=Barycentric,"
-            "RefRA=3:00:00,RefDec=45:00:00", status );
+            "RefRA=3:00:00,RefDec=45:00:00" );
          astSetD( (AstFrame *)p1spec, "RestFreq", 1.420405752e9 );
          astSetD( (AstFrame *)p1spec, "Epoch", 52413.59 );
-         AstFrame *p1pix = astFrame( 1, "Domain=GRID", status );
-         AstMapping *p1map = (AstMapping *)astZoomMap( 1, 1.0e6, " ", status );
-         AstFrameSet *p1fs = astFrameSet( p1pix, " ", status );
+         AstFrame *p1pix = astFrame( 1, "Domain=GRID" );
+         AstMapping *p1map = (AstMapping *)astZoomMap( 1, 1.0e6, " " );
+         AstFrameSet *p1fs = astFrameSet( p1pix, " " );
          astAddFrame( p1fs, AST__BASE, p1map, (AstFrame *)p1spec );
 
          AstFitsChan *p1fc = astFitsChan( NULL, NULL, "Encoding=FITS-PC" );
@@ -4017,12 +4017,12 @@ int main( void ) {
       astBegin;
 
       mfspec = astSpecFrame( "System=FREQ,Unit=Hz,StdOfRest=BARY,"
-                             "RefRA=3:00:00,RefDec=45:00:00", status );
+                             "RefRA=3:00:00,RefDec=45:00:00" );
       astSetD( (AstFrame *)mfspec, "RestFreq", 1.420405752e9 );
       astSetD( (AstFrame *)mfspec, "Epoch", 52413.59 );
-      mfpix = astFrame( 1, "Domain=GRID", status );
-      mfmap = (AstMapping *)astZoomMap( 1, 1.0e6, " ", status );
-      mffs = astFrameSet( mfpix, " ", status );
+      mfpix = astFrame( 1, "Domain=GRID" );
+      mfmap = (AstMapping *)astZoomMap( 1, 1.0e6, " " );
+      mffs = astFrameSet( mfpix, " " );
       astAddFrame( mffs, AST__BASE, mfmap, (AstFrame *)mfspec );
 
       mffc = astFitsChan( NULL, NULL, "Encoding=FITS-WCS" );
@@ -4210,15 +4210,15 @@ int main( void ) {
       astBegin;
 
       pcspec = astSpecFrame( "System=FREQ,Unit=Hz,StdOfRest=Barycentric,"
-                             "RestFreq=1.4204e9 Hz", status );
-      pcpix = astFrame( 1, "Domain=GRID", status );
-      pcmap = (AstMapping *)astZoomMap( 1, 1.0e6, " ", status );
-      pcfs = astFrameSet( pcpix, " ", status );
+                             "RestFreq=1.4204e9 Hz" );
+      pcpix = astFrame( 1, "Domain=GRID" );
+      pcmap = (AstMapping *)astZoomMap( 1, 1.0e6, " " );
+      pcfs = astFrameSet( pcpix, " " );
       astAddFrame( pcfs, AST__BASE, pcmap, (AstFrame *)pcspec );
 
       pcspec2 = astSpecFrame( "System=WAVE,Unit=m,StdOfRest=Barycentric,"
-                              "RestFreq=1.4204e9 Hz", status );
-      pcmap = (AstMapping *)astZoomMap( 1, 1.0e-10, " ", status );
+                              "RestFreq=1.4204e9 Hz" );
+      pcmap = (AstMapping *)astZoomMap( 1, 1.0e-10, " " );
       astAddFrame( pcfs, AST__BASE, pcmap, (AstFrame *)pcspec2 );
 
       astSetI( pcfs, "Current", 2 );

--- a/src/object.h.in
+++ b/src/object.h.in
@@ -332,6 +332,13 @@
 *        so the helper reports equality for pairs of values of order
 *        DBL_EPSILON (for example, the ulp-scale inverse-matrix residuals
 *        that drift between macOS and Linux math libraries).
+*     4-JUN-2026 (EMB):
+*        Change the AST__DBL_DIG fallback (used when DBL_DECIMAL_DIG is
+*        not exposed, e.g. a C99 build) from DBL_DIG + 3 to DBL_DIG + 2,
+*        so it equals DBL_DECIMAL_DIG for IEEE-754 binary64. Serialised
+*        output is now identical (17 significant digits) whether AST
+*        is built as C99 or C11, which keeps the test fixtures matching
+*        regardless of the compiler's default C standard.
 */
 
 /* Include files. */
@@ -402,12 +409,17 @@
 /* Number of digits to use when formatting double precision floating point
    values. DBL_DIG ensures no loss when round-tripping from text to
    binary to text, but we want no loss when round-tripping from binary to
-   text to binary, so we use DBL_DECIMAL_DIG instead. If this is not
-   avaialable we use DBL_DIG but add on an extra 3 digits. */
+   text to binary, so we use DBL_DECIMAL_DIG instead. DBL_DECIMAL_DIG is
+   only exposed by <float.h> under C11 and later, so when it is not
+   available (e.g. a C99 build) we fall back to DBL_DIG + 2, which equals
+   DBL_DECIMAL_DIG for IEEE-754 binary64. Keeping the two paths equal
+   means the serialised number of digits (and hence the exact text of
+   dumped Objects) is identical regardless of the C standard AST was
+   compiled against. */
 #ifdef DBL_DECIMAL_DIG
   #define AST__DBL_DIG (DBL_DECIMAL_DIG)
 #else
-  #define AST__DBL_DIG (DBL_DIG + 3)
+  #define AST__DBL_DIG (DBL_DIG + 2)
 #endif
 
 #ifdef FLT_DECIMAL_DIG


### PR DESCRIPTION
This came up at #38: https://github.com/Starlink/ast/pull/38#issuecomment-4273909152

But was never handled.  I agree that just setting the fallback `DBL_DECIMAL_DIG` to be consistent between C99 and C11 is least disruptive, and this fixes all the test failure I was having on my machine where the compiler was defaulting to C99.

Also fixed several build warnings that were coming from the Claude-generated tests (warnings that were enabled by default in GCC but maybe not in clang).