### PR TITLE
Add astGetKeyMap protected method to Object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -921,7 +921,9 @@ if(BUILD_TESTING)
                         --ignore-errors negative
                         --rc branch_coverage=1
                     COMMAND ${LCOV_EXECUTABLE}
-                        --extract "${AST_COVERAGE_FULL_INFO}" "${CMAKE_SOURCE_DIR}/src/*"
+                        --extract "${AST_COVERAGE_FULL_INFO}"
+                            "${CMAKE_SOURCE_DIR}/src/*"
+                            "${CMAKE_SOURCE_DIR}/ast_tester/*"
                         --output-file "${AST_COVERAGE_INFO}"
                         --ignore-errors unused,negative
                         --rc branch_coverage=1

--- a/ast_tester/CMakeLists.txt
+++ b/ast_tester/CMakeLists.txt
@@ -156,6 +156,7 @@ ast_add_test(testresimp INTERNAL_HEADERS)
 ast_add_test(testaxis)
 ast_add_test(testframe)
 ast_add_test(testunitnorm)
+ast_add_test(testobjectkeymap)
 
 # --- Tests needing data files ---
 configure_file(2dspline_c.dat "${CMAKE_CURRENT_BINARY_DIR}/2dspline_c.dat" COPYONLY)

--- a/ast_tester/testobject.c
+++ b/ast_tester/testobject.c
@@ -1,3 +1,5 @@
+/* Test program for the AstObject base class. */
+
 #include "ast.h"
 #include <libgen.h>
 #include <stdio.h>
@@ -12,122 +14,228 @@ static const char *baseName( const char *path ) {
    return basename( buffer );
 }
 
-int main( void ){
-   const char *routine;
-   const char *file;
-   int i;
-   int line;
-   char *pickle1;
-   char *pickle2;
+/* Verify that an Object survives a checkdump (astToString followed by
+   astFromString) round trip, and that the reloaded Object compares equal
+   to the original. */
+static void TestCheckToString( void ) {
    AstSkyFrame *sf = astSkyFrame( " " );
-   int bf_line = __LINE__ + 1;
    AstFrame *bf = astFrame( 2, "Domain=SKY" );
    AstFrameSet *fs = astConvert( bf, sf, " " );
-   AstKeyMap *km;
-   void *p;
+   AstFrameSet *fs2 = NULL;
+   char *pickle1 = NULL;
+   char *pickle2 = NULL;
 
-   if( fs ) {
+   if( !fs ) {
+      if( astOK )
+         astError( AST__INTER, "TestCheckToString: astConvert failed.\n" );
+   } else {
       pickle1 = astToString( fs );
-      int fs2_line = __LINE__ + 1;
-      AstFrameSet *fs2 = astFromString( pickle1 );
+      fs2 = astFromString( pickle1 );
       pickle2 = astToString( fs2 );
+
       if( pickle1 && pickle2 ) {
          if( strcmp( pickle1, pickle2 ) && astOK ) {
-            astError( AST__INTER, "Error 1\n" );
+            astError( AST__INTER, "TestCheckToString: round-tripped strings "
+                      "differ.\n" );
          }
       } else if( astOK ) {
-         astError( AST__INTER, "Error 2\n" );
+         astError( AST__INTER,
+                   "TestCheckToString: astToString returned NULL.\n" );
       }
-
-
-      pickle1 = astFree( pickle1 );
-      pickle2 = astFree( pickle2 );
 
       if( fs2 && !astEqual( fs, fs2 ) && astOK ) {
-         astError( AST__INTER, "Error 3\n" );
+         astError( AST__INTER,
+                   "TestCheckToString: reloaded Object is not equal "
+                   "to the original.\n" );
+      }
+   }
+
+   pickle1 = astFree( pickle1 );
+   pickle2 = astFree( pickle2 );
+   sf = astAnnul( sf );
+   bf = astAnnul( bf );
+
+   if( fs )
+      fs = astAnnul( fs );
+
+   if( fs2 )
+      fs2 = astAnnul( fs2 );
+}
+
+/* Verify that astCreatedAt reports the routine, file and line at which an
+   Object was created. */
+static void TestCreatedAt( void ) {
+   const char *routine;
+   const char *file;
+   int line;
+   int bf_line = __LINE__ + 1;
+   AstFrame *bf = astFrame( 2, "Domain=SKY" );
+
+   astCreatedAt( bf, &routine, &file, &line );
+   if( ( !routine || strcmp( routine, "TestCreatedAt" ) ) && astOK ) {
+      astError( AST__INTER, "TestCreatedAt: routine is '%s'.\n",
+                routine ? routine : "<NULL>" );
+   }
+   if( ( !file || strcmp( baseName( file ), "testobject.c" ) ) && astOK ) {
+      astError( AST__INTER, "TestCreatedAt: file is '%s'.\n",
+                file ? file : "<NULL>" );
+   }
+   if( line != bf_line && astOK ) {
+      astError( AST__INTER, "TestCreatedAt: line is %d, expected %d.\n",
+                line, bf_line );
+   }
+
+   bf = astAnnul( bf );
+}
+
+/* Verify that astActiveObjects reports the Objects active within the
+   current context, keyed by class, including the creation information for
+   each one. The objects are created within their own AST context so the
+   "current" filter yields a deterministic set regardless of any objects
+   left alive by other tests. */
+static void TestActiveObjects( void ) {
+   AstSkyFrame *sf;
+   AstFrame *bf;
+   AstFrameSet *fs;
+   AstFrameSet *fs2;
+   AstKeyMap *km;
+   const char *routine;
+   const char *file;
+   const char *key;
+   int bf_line;
+   int fs2_line;
+   int idx;
+   int jdx;
+   int found;
+   int line;
+   int nkey;
+   void *p;
+
+   astBegin;
+
+   sf = astSkyFrame( " " );
+   bf_line = __LINE__ + 1;
+   bf = astFrame( 2, "Domain=SKY" );
+   fs = astConvert( bf, sf, " " );
+   fs2_line = __LINE__ + 1;
+   fs2 = astCopy( fs );
+   km = astActiveObjects( NULL, 0, 1 );
+
+   if( !km && astOK ) {
+      astError( AST__INTER, "TestActiveObjects: astActiveObjects returned "
+                "NULL.\n" );
+   } else {
+      nkey = astMapSize( km );
+      if( nkey != 3 && astOK ) {
+         astError( AST__INTER, "TestActiveObjects: nkey is %d, expected 3.\n",
+                   nkey );
       }
 
-      astCreatedAt( bf, &routine, &file, &line );
-      if( ( !routine || strcmp( routine, "main" ) ) && astOK ) {
-         astError( AST__INTER, "Error 31\n" );
-      }
-      if( ( !file || strcmp( baseName(file), "testobject.c" ) ) && astOK ) {
-         astError( AST__INTER, "Error 32\n" );
-      }
-      if( line != bf_line && astOK ) {
-         astError( AST__INTER, "Error 33 (line is %d, expected %d)\n", line, bf_line );
-      }
-
-
-      km = astActiveObjects( NULL, 0, 0 );
-      if( !km && astOK ) {
-         astError( AST__INTER, "Error 34\n" );
-      } else {
-         int nkey = astMapSize( km );
-         if( nkey != 3 && astOK ) {
-            astError( AST__INTER, "Error 35 (nkey is %d)\n", nkey );
-         }
-
-         astSetC( km, "SortBy", "KeyUp" );
-         for( i=0; i < 3; i++ ){
-            const char *key = astMapKey( km, i );
-            if( i == 0 ) {
-               if( strcmp( key, "Frame" ) && astOK ) {
-                  astError( AST__INTER, "Error 36 (key 0 is '%s')\n", key );
-               } else if( astMapLength(km,key) != 1 && astOK ) {
-                  astError( AST__INTER, "Error 361 (%d)\n", astMapLength(km,key) );
-               } else if( ( !astMapGetElemP( km, key, 0, &p ) || ( p != bf ) ) && astOK ) {
-                  astError( AST__INTER, "Error 362\n" );
-               } else {
-                  astCreatedAt( p, &routine, &file, &line );
-                  if( ( !routine || strcmp( routine, "main" ) ) && astOK ) {
-                     astError( AST__INTER, "Error 363\n" );
-                  }
-                  if( ( !file || strcmp( baseName(file), "testobject.c" ) ) && astOK ) {
-                     astError( AST__INTER, "Error 364\n" );
-                  }
-                  if( line != bf_line && astOK ) {
-                     astError( AST__INTER, "Error 365 (line is %d)\n", line );
-                  }
-               }
-            } else if( i == 1 ) {
-               if( strcmp( key, "FrameSet" ) && astOK ) {
-                  astError( AST__INTER, "Error 37 (key 1 is '%s')\n", key );
-               } else if( astMapLength(km,key) != 2 && astOK ) {
-                  astError( AST__INTER, "Error 371 (%d)\n", astMapLength(km,key) );
-               } else if( ( !astMapGetElemP( km, key, 1, &p ) || ( p != fs2 ) ) && astOK ) {
-                  astError( AST__INTER, "Error 372\n" );
-               } else {
-                  astCreatedAt( p, &routine, &file, &line );
-                  if( ( !routine || strcmp( routine, "main" ) ) && astOK ) {
-                     astError( AST__INTER, "Error 373\n" );
-                  }
-                  if( ( !file || strcmp( baseName(file), "testobject.c" ) ) && astOK ) {
-                     astError( AST__INTER, "Error 374\n" );
-                  }
-                  if( line != fs2_line && astOK ) {
-                     astError( AST__INTER, "Error 375 (line is %d, expected %d)\n", line, fs2_line );
-                  }
-               }
+      astSetC( km, "SortBy", "KeyUp" );
+      for( idx = 0; idx < nkey; idx++ ){
+         key = astMapKey( km, idx );
+         if( idx == 0 ) {
+            if( strcmp( key, "Frame" ) && astOK ) {
+               astError( AST__INTER, "TestActiveObjects: key 0 is '%s'.\n",
+                         key );
+            } else if( astMapLength( km, key ) != 1 && astOK ) {
+               astError( AST__INTER, "TestActiveObjects: Frame count is %d.\n",
+                         astMapLength( km, key ) );
+            } else if( ( !astMapGetElemP( km, key, 0, &p ) || ( p != bf ) ) &&
+                       astOK ) {
+               astError( AST__INTER, "TestActiveObjects: Frame pointer "
+                         "mismatch.\n" );
             } else {
-               if( strcmp( key, "SkyFrame" ) && astOK ) {
-                  astError( AST__INTER, "Error 38 (key 2 is '%s')\n", key );
-               } else if( astMapLength(km,key) != 1 && astOK ) {
-                  astError( AST__INTER, "Error 381 (%d)\n", astMapLength(km,key) );
+               astCreatedAt( p, &routine, &file, &line );
+               if( ( !routine || strcmp( routine, "TestActiveObjects" ) ) &&
+                   astOK ) {
+                  astError( AST__INTER, "TestActiveObjects: Frame routine is "
+                            "'%s'.\n", routine ? routine : "<NULL>" );
                }
+               if( ( !file || strcmp( baseName( file ), "testobject.c" ) ) &&
+                   astOK ) {
+                  astError( AST__INTER, "TestActiveObjects: Frame file is "
+                            "'%s'.\n", file ? file : "<NULL>" );
+               }
+               if( line != bf_line && astOK ) {
+                  astError( AST__INTER, "TestActiveObjects: Frame line is %d, "
+                            "expected %d.\n", line, bf_line );
+               }
+            }
+         } else if( idx == 1 ) {
+            if( strcmp( key, "FrameSet" ) && astOK ) {
+               astError( AST__INTER, "TestActiveObjects: key 1 is '%s'.\n",
+                         key );
+            } else if( astMapLength( km, key ) != 2 && astOK ) {
+               astError( AST__INTER, "TestActiveObjects: FrameSet count is "
+                         "%d.\n", astMapLength( km, key ) );
+            } else {
+
+/* The two FrameSets are both active, but their order within the list is
+   determined by the order in which the underlying object handles happen
+   to be allocated, which is not the order of creation. Locate the entry
+   that corresponds to "fs2" (the FrameSet created in this routine by
+   astCopy) and verify that its recorded creation information is correct. */
+               found = 0;
+               for( jdx = 0; jdx < 2; jdx++ ) {
+                  if( astMapGetElemP( km, key, jdx, &p ) && p == fs2 ) {
+                     found = 1;
+                     astCreatedAt( p, &routine, &file, &line );
+                     if( ( !routine ||
+                           strcmp( routine, "TestActiveObjects" ) ) && astOK ) {
+                        astError( AST__INTER, "TestActiveObjects: FrameSet "
+                                  "routine is '%s'.\n",
+                                  routine ? routine : "<NULL>" );
+                     }
+                     if( ( !file ||
+                           strcmp( baseName( file ), "testobject.c" ) ) &&
+                         astOK ) {
+                        astError( AST__INTER, "TestActiveObjects: FrameSet "
+                                  "file is '%s'.\n", file ? file : "<NULL>" );
+                     }
+                     if( line != fs2_line && astOK ) {
+                        astError( AST__INTER, "TestActiveObjects: FrameSet "
+                                  "line is %d, expected %d.\n", line,
+                                  fs2_line );
+                     }
+                  }
+               }
+               if( !found && astOK ) {
+                  astError( AST__INTER, "TestActiveObjects: fs2 not found "
+                            "among the active FrameSets.\n" );
+               }
+            }
+         } else {
+            if( strcmp( key, "SkyFrame" ) && astOK ) {
+               astError( AST__INTER, "TestActiveObjects: key 2 is '%s'.\n",
+                         key );
+            } else if( astMapLength( km, key ) != 1 && astOK ) {
+               astError( AST__INTER, "TestActiveObjects: SkyFrame count is "
+                         "%d.\n", astMapLength( km, key ) );
             }
          }
       }
       km = astAnnul( km );
-
-   } else if( astOK ){
-      astError( AST__INTER, "Error 4\n"  );
    }
+
+   astEnd;
+}
+
+int main( void ){
+   astBegin;
+
+   TestCheckToString();
+   TestCreatedAt();
+   TestActiveObjects();
+
+   astEnd;
 
    if( astOK ) {
       printf(" All Object tests passed\n");
+      return 0;
    } else {
       printf("Object tests failed\n");
+      return 1;
    }
    return astOK ? 0 : 1;
 }

--- a/ast_tester/testobject.c
+++ b/ast_tester/testobject.c
@@ -27,27 +27,21 @@ static void TestCheckToString( void ) {
 
    if( !fs ) {
       if( astOK )
-         astError( AST__INTER, "TestCheckToString: astConvert failed.\n" );
+         astError( AST__INTER, "TestCheckToString: astConvert failed.\n" );  /* LCOV_EXCL_LINE */
    } else {
       pickle1 = astToString( fs );
       fs2 = astFromString( pickle1 );
       pickle2 = astToString( fs2 );
 
       if( pickle1 && pickle2 ) {
-         if( strcmp( pickle1, pickle2 ) && astOK ) {
-            astError( AST__INTER, "TestCheckToString: round-tripped strings "
-                      "differ.\n" );
-         }
+         if( strcmp( pickle1, pickle2 ) && astOK )
+            astError( AST__INTER, "TestCheckToString: round-tripped strings differ.\n" );  /* LCOV_EXCL_LINE */
       } else if( astOK ) {
-         astError( AST__INTER,
-                   "TestCheckToString: astToString returned NULL.\n" );
+         astError( AST__INTER, "TestCheckToString: astToString returned NULL.\n" );  /* LCOV_EXCL_LINE */
       }
 
-      if( fs2 && !astEqual( fs, fs2 ) && astOK ) {
-         astError( AST__INTER,
-                   "TestCheckToString: reloaded Object is not equal "
-                   "to the original.\n" );
-      }
+      if( fs2 && !astEqual( fs, fs2 ) && astOK )
+         astError( AST__INTER, "TestCheckToString: reloaded Object is not equal to the original.\n" );  /* LCOV_EXCL_LINE */
    }
 
    pickle1 = astFree( pickle1 );
@@ -72,18 +66,12 @@ static void TestCreatedAt( void ) {
    AstFrame *bf = astFrame( 2, "Domain=SKY" );
 
    astCreatedAt( bf, &routine, &file, &line );
-   if( ( !routine || strcmp( routine, "TestCreatedAt" ) ) && astOK ) {
-      astError( AST__INTER, "TestCreatedAt: routine is '%s'.\n",
-                routine ? routine : "<NULL>" );
-   }
-   if( ( !file || strcmp( baseName( file ), "testobject.c" ) ) && astOK ) {
-      astError( AST__INTER, "TestCreatedAt: file is '%s'.\n",
-                file ? file : "<NULL>" );
-   }
-   if( line != bf_line && astOK ) {
-      astError( AST__INTER, "TestCreatedAt: line is %d, expected %d.\n",
-                line, bf_line );
-   }
+   if( ( !routine || strcmp( routine, "TestCreatedAt" ) ) && astOK )
+      astError( AST__INTER, "TestCreatedAt: routine is '%s'.\n", routine ? routine : "<NULL>" );  /* LCOV_EXCL_LINE */
+   if( ( !file || strcmp( baseName( file ), "testobject.c" ) ) && astOK )
+      astError( AST__INTER, "TestCreatedAt: file is '%s'.\n", file ? file : "<NULL>" );  /* LCOV_EXCL_LINE */
+   if( line != bf_line && astOK )
+      astError( AST__INTER, "TestCreatedAt: line is %d, expected %d.\n", line, bf_line );  /* LCOV_EXCL_LINE */
 
    bf = astAnnul( bf );
 }
@@ -122,53 +110,36 @@ static void TestActiveObjects( void ) {
    km = astActiveObjects( NULL, 0, 1 );
 
    if( !km && astOK ) {
-      astError( AST__INTER, "TestActiveObjects: astActiveObjects returned "
-                "NULL.\n" );
+      astError( AST__INTER, "TestActiveObjects: astActiveObjects returned NULL.\n" );  /* LCOV_EXCL_LINE */
    } else {
       nkey = astMapSize( km );
-      if( nkey != 3 && astOK ) {
-         astError( AST__INTER, "TestActiveObjects: nkey is %d, expected 3.\n",
-                   nkey );
-      }
+      if( nkey != 3 && astOK )
+         astError( AST__INTER, "TestActiveObjects: nkey is %d, expected 3.\n", nkey );  /* LCOV_EXCL_LINE */
 
       astSetC( km, "SortBy", "KeyUp" );
       for( idx = 0; idx < nkey; idx++ ){
          key = astMapKey( km, idx );
          if( idx == 0 ) {
             if( strcmp( key, "Frame" ) && astOK ) {
-               astError( AST__INTER, "TestActiveObjects: key 0 is '%s'.\n",
-                         key );
+               astError( AST__INTER, "TestActiveObjects: key 0 is '%s'.\n", key );  /* LCOV_EXCL_LINE */
             } else if( astMapLength( km, key ) != 1 && astOK ) {
-               astError( AST__INTER, "TestActiveObjects: Frame count is %d.\n",
-                         astMapLength( km, key ) );
-            } else if( ( !astMapGetElemP( km, key, 0, &p ) || ( p != bf ) ) &&
-                       astOK ) {
-               astError( AST__INTER, "TestActiveObjects: Frame pointer "
-                         "mismatch.\n" );
+               astError( AST__INTER, "TestActiveObjects: Frame count is %d.\n", astMapLength( km, key ) );  /* LCOV_EXCL_LINE */
+            } else if( ( !astMapGetElemP( km, key, 0, &p ) || ( p != bf ) ) && astOK ) {
+               astError( AST__INTER, "TestActiveObjects: Frame pointer mismatch.\n" );  /* LCOV_EXCL_LINE */
             } else {
                astCreatedAt( p, &routine, &file, &line );
-               if( ( !routine || strcmp( routine, "TestActiveObjects" ) ) &&
-                   astOK ) {
-                  astError( AST__INTER, "TestActiveObjects: Frame routine is "
-                            "'%s'.\n", routine ? routine : "<NULL>" );
-               }
-               if( ( !file || strcmp( baseName( file ), "testobject.c" ) ) &&
-                   astOK ) {
-                  astError( AST__INTER, "TestActiveObjects: Frame file is "
-                            "'%s'.\n", file ? file : "<NULL>" );
-               }
-               if( line != bf_line && astOK ) {
-                  astError( AST__INTER, "TestActiveObjects: Frame line is %d, "
-                            "expected %d.\n", line, bf_line );
-               }
+               if( ( !routine || strcmp( routine, "TestActiveObjects" ) ) && astOK )
+                  astError( AST__INTER, "TestActiveObjects: Frame routine is '%s'.\n", routine ? routine : "<NULL>" );  /* LCOV_EXCL_LINE */
+               if( ( !file || strcmp( baseName( file ), "testobject.c" ) ) && astOK )
+                  astError( AST__INTER, "TestActiveObjects: Frame file is '%s'.\n", file ? file : "<NULL>" );  /* LCOV_EXCL_LINE */
+               if( line != bf_line && astOK )
+                  astError( AST__INTER, "TestActiveObjects: Frame line is %d, expected %d.\n", line, bf_line );  /* LCOV_EXCL_LINE */
             }
          } else if( idx == 1 ) {
             if( strcmp( key, "FrameSet" ) && astOK ) {
-               astError( AST__INTER, "TestActiveObjects: key 1 is '%s'.\n",
-                         key );
+               astError( AST__INTER, "TestActiveObjects: key 1 is '%s'.\n", key );  /* LCOV_EXCL_LINE */
             } else if( astMapLength( km, key ) != 2 && astOK ) {
-               astError( AST__INTER, "TestActiveObjects: FrameSet count is "
-                         "%d.\n", astMapLength( km, key ) );
+               astError( AST__INTER, "TestActiveObjects: FrameSet count is %d.\n", astMapLength( km, key ) );  /* LCOV_EXCL_LINE */
             } else {
 
 /* The two FrameSets are both active, but their order within the list is
@@ -181,37 +152,22 @@ static void TestActiveObjects( void ) {
                   if( astMapGetElemP( km, key, jdx, &p ) && p == fs2 ) {
                      found = 1;
                      astCreatedAt( p, &routine, &file, &line );
-                     if( ( !routine ||
-                           strcmp( routine, "TestActiveObjects" ) ) && astOK ) {
-                        astError( AST__INTER, "TestActiveObjects: FrameSet "
-                                  "routine is '%s'.\n",
-                                  routine ? routine : "<NULL>" );
-                     }
-                     if( ( !file ||
-                           strcmp( baseName( file ), "testobject.c" ) ) &&
-                         astOK ) {
-                        astError( AST__INTER, "TestActiveObjects: FrameSet "
-                                  "file is '%s'.\n", file ? file : "<NULL>" );
-                     }
-                     if( line != fs2_line && astOK ) {
-                        astError( AST__INTER, "TestActiveObjects: FrameSet "
-                                  "line is %d, expected %d.\n", line,
-                                  fs2_line );
-                     }
+                     if( ( !routine || strcmp( routine, "TestActiveObjects" ) ) && astOK )
+                        astError( AST__INTER, "TestActiveObjects: FrameSet routine is '%s'.\n", routine ? routine : "<NULL>" );  /* LCOV_EXCL_LINE */
+                     if( ( !file || strcmp( baseName( file ), "testobject.c" ) ) && astOK )
+                        astError( AST__INTER, "TestActiveObjects: FrameSet file is '%s'.\n", file ? file : "<NULL>" );  /* LCOV_EXCL_LINE */
+                     if( line != fs2_line && astOK )
+                        astError( AST__INTER, "TestActiveObjects: FrameSet line is %d, expected %d.\n", line, fs2_line );  /* LCOV_EXCL_LINE */
                   }
                }
-               if( !found && astOK ) {
-                  astError( AST__INTER, "TestActiveObjects: fs2 not found "
-                            "among the active FrameSets.\n" );
-               }
+               if( !found && astOK )
+                  astError( AST__INTER, "TestActiveObjects: fs2 not found among the active FrameSets.\n" );  /* LCOV_EXCL_LINE */
             }
          } else {
             if( strcmp( key, "SkyFrame" ) && astOK ) {
-               astError( AST__INTER, "TestActiveObjects: key 2 is '%s'.\n",
-                         key );
+               astError( AST__INTER, "TestActiveObjects: key 2 is '%s'.\n", key );  /* LCOV_EXCL_LINE */
             } else if( astMapLength( km, key ) != 1 && astOK ) {
-               astError( AST__INTER, "TestActiveObjects: SkyFrame count is "
-                         "%d.\n", astMapLength( km, key ) );
+               astError( AST__INTER, "TestActiveObjects: SkyFrame count is %d.\n", astMapLength( km, key ) );  /* LCOV_EXCL_LINE */
             }
          }
       }

--- a/ast_tester/testobjectkeymap.c
+++ b/ast_tester/testobjectkeymap.c
@@ -1,0 +1,162 @@
+/* Test program for the protected astGetKeyMap method of the Object class.
+ *
+ * astGetKeyMap is a protected method, so (like testaxis.c and
+ * testunitnorm.c) this test is compiled with astCLASS defined and uses the
+ * protected interface directly.
+ *
+ * The behaviour covered here includes:
+ *   - Lazy creation of an empty KeyMap on first access
+ *   - A stable, borrowed reference returned by repeated requests
+ *   - A deep-copy of the KeyMap taken by astCopy
+ *   - Serialisation that preserves a non-empty KeyMap but omits an empty
+ *     one (ensuring that existing Object dumps are unmodified).
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "sae_par.h"
+#include "ast_err.h"
+
+/* Just ensure astCLASS is defined; what it's defined as is arbitrary for this
+   purpose */
+#define astCLASS testobjectkeymap
+#include "memory.h"
+#include "object.h"
+#include "frame.h"
+#include "keymap.h"
+
+void astBegin_( void );
+void astEnd_( int * );
+
+static void TestCreate( int *status ) {
+   AstFrame *frm = astFrame( 2, " ", status );
+   AstKeyMap *km1;
+   AstKeyMap *km2;
+
+/* A new Object lazily creates an empty KeyMap on the first request. */
+   km1 = astGetKeyMap( frm );
+   if( !km1 && astOK ) {
+      astError( AST__INTER, "TestCreate: astGetKeyMap returned NULL.\n",
+                status );
+   } else if( astMapSize( km1 ) != 0 && astOK ) {
+      astError( AST__INTER, "TestCreate: New KeyMap not empty (size %d).\n",
+                status, astMapSize( km1 ) );
+   }
+
+/* Repeated requests return the same borrowed pointer. */
+   km2 = astGetKeyMap( frm );
+   if( km1 != km2 && astOK ) {
+      astError( AST__INTER,
+                "TestCreate: astGetKeyMap returned different pointers.\n",
+                status );
+   }
+
+   frm = astAnnul( frm );
+}
+
+static void TestCopy( int *status ) {
+   AstFrame *frm = astFrame( 2, " ", status );
+   AstFrame *copy;
+   AstKeyMap *km1;
+   AstKeyMap *km2;
+   int v;
+
+/* Store some data in the KeyMap. */
+   km1 = astGetKeyMap( frm );
+   astMapPut0I( km1, "answer", 42, NULL );
+
+/* astCopy takes a deep-copy of the KeyMap. */
+   copy = astCopy( frm );
+   km2 = astGetKeyMap( copy );
+   if( km2 == km1 && astOK ) {
+      astError( AST__INTER,
+                "TestCopy: Copy shares its KeyMap with the original.\n",
+                status );
+   }
+   v = 0;
+   if( ( !astMapGet0I( km2, "answer", &v ) || v != 42 ) && astOK ) {
+      astError( AST__INTER,
+                "TestCopy: Copied KeyMap is missing data (got %d).\n",
+                status, v );
+   }
+
+/* Modifying the copy's KeyMap does not affect the original. */
+   astMapPut0I( km2, "answer", 7, NULL );
+   v = 0;
+   astMapGet0I( km1, "answer", &v );
+   if( v != 42 && astOK ) {
+      astError( AST__INTER,
+                "TestCopy: Modifying the copy affected the original "
+                "(got %d).\n", status, v );
+   }
+
+   frm = astAnnul( frm );
+   copy = astAnnul( copy );
+}
+
+static void TestToString( int *status ) {
+   AstFrame *frm1 = astFrame( 2, " ", status );
+   AstFrame *frm2;
+   AstFrame *empty;
+   AstKeyMap *km1;
+   AstKeyMap *km2;
+   char *str;
+   int v;
+
+/* Store some data in the KeyMap. */
+   km1 = astGetKeyMap( frm1 );
+   astMapPut0I( km1, "answer", 42, NULL );
+
+/* A non-empty KeyMap survives a round trip. */
+   str = astToString( frm1 );
+   if( str && !strstr( str, "KeyMap" ) && astOK ) {
+      astError( AST__INTER,
+                "TestToString: Non-empty KeyMap was not serialised.\n",
+                status );
+   }
+   frm2 = astFromString( str );
+   km2 = astGetKeyMap( frm2 );
+   v = 0;
+   if( ( !astMapGet0I( km2, "answer", &v ) || v != 42 ) && astOK ) {
+      astError( AST__INTER,
+                "TestToString: Reloaded KeyMap is missing data (got %d).\n",
+                status, v );
+   }
+   str = astFree( str );
+
+/* An empty KeyMap is not serialised at all, so the dump of an Object whose
+   KeyMap exists but is empty must be free of any "KeyMap" item. */
+   empty = astFrame( 2, " ", status );
+   (void) astGetKeyMap( empty );
+   str = astToString( empty );
+   if( str && strstr( str, "KeyMap" ) && astOK ) {
+      astError( AST__INTER, "TestToString: Empty KeyMap was serialised.\n",
+                status );
+   }
+   str = astFree( str );
+
+   frm1 = astAnnul( frm1 );
+   frm2 = astAnnul( frm2 );
+   empty = astAnnul( empty );
+}
+
+int main( void ) {
+   int _status = SAI__OK;
+   int *status = &_status;
+   astWatch( status );
+   astBegin_();
+
+   TestCreate( status );
+   TestCopy( status );
+   TestToString( status );
+
+   astEnd_( status );
+
+   if( astOK ) {
+      printf(" All Object KeyMap tests passed\n");
+      return 0;
+   } else {
+      printf("Object KeyMap tests failed\n");
+      return 1;
+   }
+}

--- a/ast_tester/testobjectkeymap.c
+++ b/ast_tester/testobjectkeymap.c
@@ -6,10 +6,11 @@
  *
  * The behaviour covered here includes:
  *   - Lazy creation of an empty KeyMap on first access
- *   - A stable, borrowed reference returned by repeated requests
+ *   - Repeated requests returning references to the same KeyMap
  *   - A deep-copy of the KeyMap taken by astCopy
  *   - Serialisation that preserves a non-empty KeyMap but omits an empty
- *     one (ensuring that existing Object dumps are unmodified).
+ *     one (ensuring that existing Object dumps are unmodified)
+ *   - Inclusion of the KeyMap in the reported ObjSize.
  */
 
 #include <stdio.h>
@@ -41,11 +42,17 @@ static void TestCreate( int *status ) {
       astError( AST__INTER, "TestCreate: New KeyMap not empty (size %d).\n", status, astMapSize( km1 ) );  /* LCOV_EXCL_LINE */
    }
 
-/* Repeated requests return the same borrowed pointer. */
+/* Repeated requests return references to the same KeyMap. Compare with
+   astSame rather than the pointer values directly--since this is just testing
+   the internal interface comparing pointers directly happens to work too, but
+   that's an implementation detal. Better stick to the API contract, also in
+   case we make this a public API later. */
    km2 = astGetKeyMap( frm );
-   if( km1 != km2 && astOK )
-      astError( AST__INTER, "TestCreate: astGetKeyMap returned different pointers.\n", status );  /* LCOV_EXCL_LINE */
+   if( !astSame( km1, km2 ) && astOK )
+      astError( AST__INTER, "TestCreate: astGetKeyMap returned different KeyMaps.\n", status );  /* LCOV_EXCL_LINE */
 
+   km1 = astAnnul( km1 );
+   km2 = astAnnul( km2 );
    frm = astAnnul( frm );
 }
 
@@ -63,7 +70,7 @@ static void TestCopy( int *status ) {
 /* astCopy takes a deep-copy of the KeyMap. */
    copy = astCopy( frm );
    km2 = astGetKeyMap( copy );
-   if( km2 == km1 && astOK )
+   if( astSame( km1, km2 ) && astOK )
       astError( AST__INTER, "TestCopy: Copy shares its KeyMap with the original.\n", status );  /* LCOV_EXCL_LINE */
    v = 0;
    if( ( !astMapGet0I( km2, "answer", &v ) || v != 42 ) && astOK )
@@ -76,6 +83,8 @@ static void TestCopy( int *status ) {
    if( v != 42 && astOK )
       astError( AST__INTER, "TestCopy: Modifying the copy affected the original (got %d).\n", status, v );  /* LCOV_EXCL_LINE */
 
+   km1 = astAnnul( km1 );
+   km2 = astAnnul( km2 );
    frm = astAnnul( frm );
    copy = astAnnul( copy );
 }
@@ -86,6 +95,7 @@ static void TestToString( int *status ) {
    AstFrame *empty;
    AstKeyMap *km1;
    AstKeyMap *km2;
+   AstKeyMap *km3;
    char *str;
    int v;
 
@@ -107,15 +117,45 @@ static void TestToString( int *status ) {
 /* An empty KeyMap is not serialised at all, so the dump of an Object whose
    KeyMap exists but is empty must be free of any "KeyMap" item. */
    empty = astFrame( 2, " ", status );
-   (void) astGetKeyMap( empty );
+   km3 = astGetKeyMap( empty );
    str = astToString( empty );
    if( str && strstr( str, "KeyMap" ) && astOK )
       astError( AST__INTER, "TestToString: Empty KeyMap was serialised.\n", status );  /* LCOV_EXCL_LINE */
    str = astFree( str );
 
+   km1 = astAnnul( km1 );
+   km2 = astAnnul( km2 );
+   km3 = astAnnul( km3 );
    frm1 = astAnnul( frm1 );
    frm2 = astAnnul( frm2 );
    empty = astAnnul( empty );
+}
+
+static void TestObjSize( int *status ) {
+   AstFrame *frm = astFrame( 2, " ", status );
+   AstKeyMap *km;
+   size_t kmsize;
+   size_t size0;
+   size_t size1;
+
+/* The reported size of the Object before it has an associated KeyMap. */
+   size0 = astGetObjSize( frm );
+
+/* Creating the KeyMap and re-measuring should increase the reported size
+   by exactly the size of the KeyMap, confirming that astGetObjSize takes
+   the associated KeyMap into account. */
+   km = astGetKeyMap( frm );
+   kmsize = astGetObjSize( km );
+
+   if( kmsize == 0 && astOK )
+      astError( AST__INTER, "TestObjSize: KeyMap size should be non-zero\n", status ); /* LCOV_EXCL_LINE */
+
+   size1 = astGetObjSize( frm );
+   if( size1 != size0 + kmsize && astOK )
+      astError( AST__INTER, "TestObjSize: ObjSize does not include the KeyMap (%d != %d + %d).\n", status, (int) size1, (int) size0, (int) kmsize );  /* LCOV_EXCL_LINE */
+
+   km = astAnnul( km );
+   frm = astAnnul( frm );
 }
 
 int main( void ) {
@@ -127,6 +167,7 @@ int main( void ) {
    TestCreate( status );
    TestCopy( status );
    TestToString( status );
+   TestObjSize( status );
 
    astEnd_( status );
 

--- a/ast_tester/testobjectkeymap.c
+++ b/ast_tester/testobjectkeymap.c
@@ -34,6 +34,11 @@ static void TestCreate( int *status ) {
    AstKeyMap *km1;
    AstKeyMap *km2;
 
+/* A new Object has no associated KeyMap, and astHasKeyMap does not create
+   one. */
+   if( astHasKeyMap( frm ) && astOK )
+      astError( AST__INTER, "TestCreate: New Object already has a KeyMap.\n", status );  /* LCOV_EXCL_LINE */
+
 /* A new Object lazily creates an empty KeyMap on the first request. */
    km1 = astGetKeyMap( frm );
    if( !km1 && astOK ) {
@@ -41,6 +46,10 @@ static void TestCreate( int *status ) {
    } else if( astMapSize( km1 ) != 0 && astOK ) {
       astError( AST__INTER, "TestCreate: New KeyMap not empty (size %d).\n", status, astMapSize( km1 ) );  /* LCOV_EXCL_LINE */
    }
+
+/* After astGetKeyMap the Object reports that it has a KeyMap. */
+   if( !astHasKeyMap( frm ) && astOK )
+      astError( AST__INTER, "TestCreate: astHasKeyMap false after astGetKeyMap.\n", status );  /* LCOV_EXCL_LINE */
 
 /* Repeated requests return references to the same KeyMap. Compare with
    astSame rather than the pointer values directly--since this is just testing

--- a/ast_tester/testobjectkeymap.c
+++ b/ast_tester/testobjectkeymap.c
@@ -36,20 +36,15 @@ static void TestCreate( int *status ) {
 /* A new Object lazily creates an empty KeyMap on the first request. */
    km1 = astGetKeyMap( frm );
    if( !km1 && astOK ) {
-      astError( AST__INTER, "TestCreate: astGetKeyMap returned NULL.\n",
-                status );
+      astError( AST__INTER, "TestCreate: astGetKeyMap returned NULL.\n", status );  /* LCOV_EXCL_LINE */
    } else if( astMapSize( km1 ) != 0 && astOK ) {
-      astError( AST__INTER, "TestCreate: New KeyMap not empty (size %d).\n",
-                status, astMapSize( km1 ) );
+      astError( AST__INTER, "TestCreate: New KeyMap not empty (size %d).\n", status, astMapSize( km1 ) );  /* LCOV_EXCL_LINE */
    }
 
 /* Repeated requests return the same borrowed pointer. */
    km2 = astGetKeyMap( frm );
-   if( km1 != km2 && astOK ) {
-      astError( AST__INTER,
-                "TestCreate: astGetKeyMap returned different pointers.\n",
-                status );
-   }
+   if( km1 != km2 && astOK )
+      astError( AST__INTER, "TestCreate: astGetKeyMap returned different pointers.\n", status );  /* LCOV_EXCL_LINE */
 
    frm = astAnnul( frm );
 }
@@ -68,27 +63,18 @@ static void TestCopy( int *status ) {
 /* astCopy takes a deep-copy of the KeyMap. */
    copy = astCopy( frm );
    km2 = astGetKeyMap( copy );
-   if( km2 == km1 && astOK ) {
-      astError( AST__INTER,
-                "TestCopy: Copy shares its KeyMap with the original.\n",
-                status );
-   }
+   if( km2 == km1 && astOK )
+      astError( AST__INTER, "TestCopy: Copy shares its KeyMap with the original.\n", status );  /* LCOV_EXCL_LINE */
    v = 0;
-   if( ( !astMapGet0I( km2, "answer", &v ) || v != 42 ) && astOK ) {
-      astError( AST__INTER,
-                "TestCopy: Copied KeyMap is missing data (got %d).\n",
-                status, v );
-   }
+   if( ( !astMapGet0I( km2, "answer", &v ) || v != 42 ) && astOK )
+      astError( AST__INTER, "TestCopy: Copied KeyMap is missing data (got %d).\n", status, v );  /* LCOV_EXCL_LINE */
 
 /* Modifying the copy's KeyMap does not affect the original. */
    astMapPut0I( km2, "answer", 7, NULL );
    v = 0;
    astMapGet0I( km1, "answer", &v );
-   if( v != 42 && astOK ) {
-      astError( AST__INTER,
-                "TestCopy: Modifying the copy affected the original "
-                "(got %d).\n", status, v );
-   }
+   if( v != 42 && astOK )
+      astError( AST__INTER, "TestCopy: Modifying the copy affected the original (got %d).\n", status, v );  /* LCOV_EXCL_LINE */
 
    frm = astAnnul( frm );
    copy = astAnnul( copy );
@@ -109,19 +95,13 @@ static void TestToString( int *status ) {
 
 /* A non-empty KeyMap survives a round trip. */
    str = astToString( frm1 );
-   if( str && !strstr( str, "KeyMap" ) && astOK ) {
-      astError( AST__INTER,
-                "TestToString: Non-empty KeyMap was not serialised.\n",
-                status );
-   }
+   if( str && !strstr( str, "KeyMap" ) && astOK )
+      astError( AST__INTER, "TestToString: Non-empty KeyMap was not serialised.\n", status );  /* LCOV_EXCL_LINE */
    frm2 = astFromString( str );
    km2 = astGetKeyMap( frm2 );
    v = 0;
-   if( ( !astMapGet0I( km2, "answer", &v ) || v != 42 ) && astOK ) {
-      astError( AST__INTER,
-                "TestToString: Reloaded KeyMap is missing data (got %d).\n",
-                status, v );
-   }
+   if( ( !astMapGet0I( km2, "answer", &v ) || v != 42 ) && astOK )
+      astError( AST__INTER, "TestToString: Reloaded KeyMap is missing data (got %d).\n", status, v );  /* LCOV_EXCL_LINE */
    str = astFree( str );
 
 /* An empty KeyMap is not serialised at all, so the dump of an Object whose
@@ -129,10 +109,8 @@ static void TestToString( int *status ) {
    empty = astFrame( 2, " ", status );
    (void) astGetKeyMap( empty );
    str = astToString( empty );
-   if( str && strstr( str, "KeyMap" ) && astOK ) {
-      astError( AST__INTER, "TestToString: Empty KeyMap was serialised.\n",
-                status );
-   }
+   if( str && strstr( str, "KeyMap" ) && astOK )
+      astError( AST__INTER, "TestToString: Empty KeyMap was serialised.\n", status );  /* LCOV_EXCL_LINE */
    str = astFree( str );
 
    frm1 = astAnnul( frm1 );
@@ -156,7 +134,7 @@ int main( void ) {
       printf(" All Object KeyMap tests passed\n");
       return 0;
    } else {
-      printf("Object KeyMap tests failed\n");
+      printf("Object KeyMap tests failed\n");  /* LCOV_EXCL_LINE */
       return 1;
    }
 }

--- a/src/object.c
+++ b/src/object.c
@@ -242,10 +242,8 @@ f     - AST_VERSION: Return the verson of the AST library being used.
 *        that it does not report an error if the supplied object handle
 *        is owned by a different thread.
 *     16-JUN-2026 (EMB):
-*        Add the protected astGetKeyMap method, which lazily creates and
-*        returns a borrowed pointer to a KeyMap associated with any Object.
-*        The KeyMap is deep-copied by astCopy, serialised through a Channel
-*        only if it exists and is not empty.
+*        Add the protected astGetKeyMap method, which returns a KeyMap that
+*        may be associated with any Object for storing extra internal data.
 *class--
 */
 
@@ -2358,11 +2356,21 @@ static size_t GetObjSize( AstObject *this, int *status ) {
 *-
 */
 
-/* Check the global error status. */
-   if ( !astOK ) return 0;
+/* Local Variables: */
+   size_t result;                /* Result value to return */
 
-/* Return the object size. */
-   return this->size;
+/* Check the global error status. */
+   if ( !astOK )
+      return 0;
+
+/* Start with the size of the Object structure itself, and then add on the
+   size of any associated KeyMap. */
+   result = this->size;
+   if ( this->keymap )
+      result += astGetObjSize( this->keymap );
+
+/* Return the total size. */
+   return result;
 }
 
 void *astGetProxy_( AstObject *this, int *status ) {
@@ -2434,21 +2442,21 @@ AstKeyMap *astGetKeyMap_( AstObject *this, int *status ) {
 *     additional data within the Object. If the Object does not yet have
 *     an associated KeyMap, a new, empty KeyMap is created.
 *
-*     The returned KeyMap is owned by the Object: it is deep-copied
-*     whenever the Object is copied (using astCopy), it is annulled when
-*     the Object is deleted, and it is written out through a Channel (as
-*     part of the Object's serialisation) only if it is not empty. This
-*     provides a general-purpose scratch area for internal use that survives
-*     copying and serialisation.
+*     The KeyMap is retained by the Object: it is deep-copied whenever the
+*     Object is copied (using astCopy), it is annulled when the Object is
+*     deleted, and it is written out through a Channel (as part of the
+*     Object's serialisation) only if it is not empty. This provides a
+*     general-purpose scratch area for internal use that survives copying
+*     and serialisation.
 
 *  Parameters:
 *     this
 *        Pointer to the Object.
 
 *  Returned Value:
-*     A borrowed pointer to the associated KeyMap, or NULL if an error
-*     occurs. The returned pointer remains owned by the Object and so
-*     should not be annulled by the caller.
+*     A pointer to the associated KeyMap, or NULL if an error occurs. This
+*     is a cloned pointer (a new reference to the KeyMap retained by the
+*     Object) and should be annulled by the caller when no longer needed.
 
 *  Notes:
 *     - This is a protected method, intended for internal use within the
@@ -2465,14 +2473,13 @@ AstKeyMap *astGetKeyMap_( AstObject *this, int *status ) {
       return NULL;
 
 /* If the Object does not yet have an associated KeyMap, create a new
-   empty one. The Object holds the only reference to this KeyMap, so the
-   pointer returned here is "borrowed" and must not be annulled by the
-   caller. */
+   empty one, retained by the Object. */
    if ( !this->keymap )
       this->keymap = astKeyMap( "", status );
 
-/* Return the borrowed pointer. */
-   return this->keymap;
+/* Return a a new reference to the retained KeyMap, which the caller
+   should annul when no longer needed. */
+   return astClone( this->keymap );
 }
 
 int astGetRefCount_( AstObject *this, int *status ) {
@@ -3054,6 +3061,12 @@ static int ManageLock( AstObject *this, int mode, int extra,
 
 /* If the operation failed, return a pointer to the failed object. */
    if( result && fail ) *fail = this;
+
+/* If the operation on "this" succeeded, perform the same operation on any
+   KeyMap associated with the Object (and, in turn, on any Objects stored
+   within that KeyMap). */
+   if( !result && this->keymap )
+      result = astManageLock( this->keymap, mode, extra, fail );
 
 /* Return the status value */
    return result;

--- a/src/object.c
+++ b/src/object.c
@@ -238,9 +238,14 @@ f     - AST_VERSION: Return the verson of the AST library being used.
 *        structure by 20 bytes. If this turns out to be problematic
 *        this facility could be controlled using a configure option.
 *     21-NOV-2019 (DSB):
-*        Include thrThread in public metrhod list, and change it so 
+*        Include thrThread in public method list, and change it so
 *        that it does not report an error if the supplied object handle
 *        is owned by a different thread.
+*     16-JUN-2026 (EMB):
+*        Add the protected astGetKeyMap method, which lazily creates and
+*        returns a borrowed pointer to a KeyMap associated with any Object.
+*        The KeyMap is deep-copied by astCopy, serialised through a Channel
+*        only if it exists and is not empty.
 *class--
 */
 
@@ -1415,6 +1420,13 @@ f     function is invoked with STATUS set to an error value, or if it
          new->ident = astStore( NULL, this->ident, strlen( this->ident ) + 1 );
       }
 
+/* Take a deep-copy of any associated KeyMap, if any. */
+      if( this->keymap ) {
+         new->keymap = astCopy( this->keymap );
+      } else {
+         new->keymap = NULL;
+      }
+
 /* Create a new mutex for the new Object, and lock it for use by the
    current thread. */
 #ifdef THREAD_SAFE
@@ -1555,6 +1567,10 @@ f     value
 /* Free the ID strings. */
    this->id = astFree( this->id );
    this->ident = astFree( this->ident );
+
+/* Annul any associated KeyMap (the Object holds the only reference). */
+   if( this->keymap )
+      this->keymap = astAnnul( this->keymap );
 
 /* Attempt to unlock the Object and destroy its mutexes. */
 #if defined(THREAD_SAFE)
@@ -1711,6 +1727,16 @@ static void Dump( AstObject *this, AstChannel *channel, int *status ) {
    vtab = this->vtab;
    astWriteInt( channel, "Nobj", 0, 0, vtab->nobject,
                 "Count of active Objects in same class" );
+
+/* KeyMap. */
+/* ------- */
+/* Write out any associated KeyMap, but only if it exists and is not
+   empty. This keeps the external representation of Objects that have no
+   associated data (the overwhelming majority) unchanged. */
+   if( this->keymap && astMapSize( this->keymap ) > 0 ) {
+      astWriteObject( channel, "KeyMap", 1, 1, this->keymap,
+                      "KeyMap of associated data" );
+   }
 
 /* Terminate the information above with an "IsA" item for the base
    Object class. */
@@ -2381,6 +2407,72 @@ void *astGetProxy_( AstObject *this, int *status ) {
 *-
 */
    return this ? this->proxy : NULL;
+}
+
+AstKeyMap *astGetKeyMap_( AstObject *this, int *status ) {
+/*
+*+
+*  Name:
+*     astGetKeyMap
+
+*  Purpose:
+*     Get a pointer to the KeyMap associated with an Object.
+
+*  Type:
+*     Protected function.
+
+*  Synopsis:
+*     #include "object.h"
+*     AstKeyMap *astGetKeyMap( AstObject *this )
+
+*  Class Membership:
+*     Object method.
+
+*  Description:
+*     This function returns a pointer to a KeyMap that is associated with
+*     the supplied Object and which may be used to stash arbitrary
+*     additional data within the Object. If the Object does not yet have
+*     an associated KeyMap, a new, empty KeyMap is created.
+*
+*     The returned KeyMap is owned by the Object: it is deep-copied
+*     whenever the Object is copied (using astCopy), it is annulled when
+*     the Object is deleted, and it is written out through a Channel (as
+*     part of the Object's serialisation) only if it is not empty. This
+*     provides a general-purpose scratch area for internal use that survives
+*     copying and serialisation.
+
+*  Parameters:
+*     this
+*        Pointer to the Object.
+
+*  Returned Value:
+*     A borrowed pointer to the associated KeyMap, or NULL if an error
+*     occurs. The returned pointer remains owned by the Object and so
+*     should not be annulled by the caller.
+
+*  Notes:
+*     - This is a protected method, intended for internal use within the
+*     AST library only. It is deliberately not part of the public
+*     interface, partly in order to avoid becoming a rat's nest of user-
+*     supplied unstructured data.
+*     - A NULL pointer will be returned if this function is invoked with
+*     the AST error status set, or if it should fail for any reason.
+*-
+*/
+
+/* Check the global error status. */
+   if ( !astOK )
+      return NULL;
+
+/* If the Object does not yet have an associated KeyMap, create a new
+   empty one. The Object holds the only reference to this KeyMap, so the
+   pointer returned here is "borrowed" and must not be annulled by the
+   caller. */
+   if ( !this->keymap )
+      this->keymap = astKeyMap( "", status );
+
+/* Return the borrowed pointer. */
+   return this->keymap;
 }
 
 int astGetRefCount_( AstObject *this, int *status ) {
@@ -5677,6 +5769,10 @@ AstObject *astInitObject_( void *mem, size_t size, int init,
 /* Initialise the pointer to an external object that acts as a proxy for
    the AST Object within foreign language interfaces. */
          new->proxy = NULL;
+
+/* Initialise the pointer to the optional KeyMap of associated data. This
+   is created on demand by astGetKeyMap. */
+         new->keymap = NULL;
       }
 
 /* If an error occurred, clean up by deleting the new Object. Otherwise
@@ -5836,6 +5932,10 @@ AstObject *astLoadObject_( void *mem, size_t size,
 /* Initialise the pointer to an external object that acts as a proxy for
    the AST Object within foreign language interfaces. */
       new->proxy = NULL;
+
+/* Read any associated KeyMap. This will be a NULL pointer if the external
+   representation did not include one (the usual case). */
+      new->keymap = astReadObject( channel, "keymap", NULL );
 
 /* If an error occurred, clean up by deleting the new Object. */
       if ( !astOK ) new = astDelete( new );

--- a/src/object.c
+++ b/src/object.c
@@ -244,6 +244,8 @@ f     - AST_VERSION: Return the verson of the AST library being used.
 *     16-JUN-2026 (EMB):
 *        Add the protected astGetKeyMap method, which returns a KeyMap that
 *        may be associated with any Object for storing extra internal data.
+*        The companion astHasKeyMap method tests whether an Object already has
+*        an associated KeyMap without creating one.
 *class--
 */
 
@@ -2480,6 +2482,56 @@ AstKeyMap *astGetKeyMap_( AstObject *this, int *status ) {
 /* Return a a new reference to the retained KeyMap, which the caller
    should annul when no longer needed. */
    return astClone( this->keymap );
+}
+
+int astHasKeyMap_( AstObject *this, int *status ) {
+/*
+*+
+*  Name:
+*     astHasKeyMap
+
+*  Purpose:
+*     Does an Object already have an associated KeyMap?
+
+*  Type:
+*     Protected function.
+
+*  Synopsis:
+*     #include "object.h"
+*     int astHasKeyMap( AstObject *this )
+
+*  Class Membership:
+*     Object method.
+
+*  Description:
+*     This function reports whether the supplied Object already has an
+*     associated KeyMap (see astGetKeyMap). Unlike astGetKeyMap, it does
+*     not create a new KeyMap if none exists, so it can be used to test for
+*     the presence of stashed data without the side effect of attaching an
+*     empty KeyMap to the Object.
+
+*  Parameters:
+*     this
+*        Pointer to the Object.
+
+*  Returned Value:
+*     A non-zero value if the Object has an associated KeyMap, or zero if it
+*     does not (or if an error occurs).
+
+*  Notes:
+*     - This is a protected method, intended for internal use within the
+*     AST library only.
+*     - Zero will be returned if this function is invoked with the AST error
+*     status set, or if it should fail for any reason.
+*-
+*/
+
+/* Check the global error status. */
+   if ( !astOK )
+      return 0;
+
+/* Report whether the Object has an associated KeyMap. */
+   return ( this->keymap != NULL );
 }
 
 int astGetRefCount_( AstObject *this, int *status ) {

--- a/src/object.h.in
+++ b/src/object.h.in
@@ -127,6 +127,9 @@
 *           Obtain the value of the ID attribute for an Object.
 *        astGetIdent
 *           Obtain the value of the Ident attribute for an Object.
+*        astGetKeyMap
+*           Obtain a pointer to the Object's associated KeyMap,
+*           creating an empty KeyMap if it does not yet exist.
 *        astGetNobject
 *           Obtain the value of the Nobject attribute for an Object.
 *        astGetRefCount
@@ -339,6 +342,12 @@
 *        output is now identical (17 significant digits) whether AST
 *        is built as C99 or C11, which keeps the test fixtures matching
 *        regardless of the compiler's default C standard.
+*     16-JUN-2026 (EMB):
+*        Added the protected astGetKeyMap method, which lazily creates and
+*        returns a borrowed pointer to a KeyMap associated with any Object.
+*        The KeyMap is deep-copied when the Object is copied, annulled when
+*        the Object is deleted, and serialised through a Channel only if it
+*        exists and is not empty.
 */
 
 /* Include files. */
@@ -1543,6 +1552,9 @@ typedef struct AstObject {
    void *proxy;                  /* A pointer to an external object that
                                     acts as a foreign language proxy for the
                                     AST object */
+   struct AstKeyMap *keymap;     /* Optional KeyMap holding arbitrary data
+                                    associated with the Object, for internal
+                                    use. Created on demand by astGetKeyMap. */
 #if defined(THREAD_SAFE)
    int locker;                   /* Thread that has locked this Object */
    pthread_mutex_t mutex1;       /* Guards access to all elements of the
@@ -1569,6 +1581,7 @@ typedef struct AstClassIdentifier {
    now. */
 struct AstChannel;
 struct KeyMap;
+struct AstKeyMap;
 
 /* This table contains all information that is the same for all
    objects in the class (e.g. pointers to its virtual functions). */
@@ -1786,6 +1799,7 @@ const char *astGetAttrib_( AstObject *, const char *, int * );
 const char *astGetClass_( const AstObject *, int * );
 const char *astGetID_( AstObject *, int * );
 const char *astGetIdent_( AstObject *, int * );
+struct AstKeyMap *astGetKeyMap_( AstObject *, int * );
 int astClassCompare_( AstObjectVtab *, AstObjectVtab *, int * );
 int astGetNobject_( const AstObject *, int * );
 int astGetRefCount_( AstObject *, int * );
@@ -1964,6 +1978,7 @@ astINVOKE(V,astGetAttrib_(astCheckObject(this),attrib,STATUS_PTR))
 #define astGetClass(this) astINVOKE(V,astGetClass_((const AstObject *)(this),STATUS_PTR))
 #define astGetID(this) astINVOKE(V,astGetID_(astCheckObject(this),STATUS_PTR))
 #define astGetIdent(this) astINVOKE(V,astGetIdent_(astCheckObject(this),STATUS_PTR))
+#define astGetKeyMap(this) astINVOKE(O,astGetKeyMap_(astCheckObject(this),STATUS_PTR))
 #define astGetNobject(this) astINVOKE(V,astGetNobject_(astCheckObject(this),STATUS_PTR))
 #define astClassCompare(class1,class2) astClassCompare_(class1,class2,STATUS_PTR)
 #define astGetRefCount(this) astINVOKE(V,astGetRefCount_(astCheckObject(this),STATUS_PTR))

--- a/src/object.h.in
+++ b/src/object.h.in
@@ -128,7 +128,7 @@
 *        astGetIdent
 *           Obtain the value of the Ident attribute for an Object.
 *        astGetKeyMap
-*           Obtain a pointer to the Object's associated KeyMap,
+*           Obtain a (cloned) pointer to the Object's associated KeyMap,
 *           creating an empty KeyMap if it does not yet exist.
 *        astGetNobject
 *           Obtain the value of the Nobject attribute for an Object.
@@ -343,11 +343,11 @@
 *        is built as C99 or C11, which keeps the test fixtures matching
 *        regardless of the compiler's default C standard.
 *     16-JUN-2026 (EMB):
-*        Added the protected astGetKeyMap method, which lazily creates and
-*        returns a borrowed pointer to a KeyMap associated with any Object.
-*        The KeyMap is deep-copied when the Object is copied, annulled when
-*        the Object is deleted, and serialised through a Channel only if it
-*        exists and is not empty.
+*        Added the protected astGetKeyMap method, which returns a KeyMap
+*        that may be associated with any Object as a scratch area for storing
+*        extra internal data.  May be useful to add to the public API later,
+*        though there is a danger there of users building ad-hoc data models
+*        around it; for now it is only intended for internal use.
 */
 
 /* Include files. */

--- a/src/object.h.in
+++ b/src/object.h.in
@@ -134,6 +134,8 @@
 *           Obtain the value of the Nobject attribute for an Object.
 *        astGetRefCount
 *           Obtain the value of the RefCount attribute for an Object.
+*        astHasKeyMap
+*           Does the Object already have an associated KeyMap?
 *        astSetAttrib
 *           Set the value of a specified attribute for an Object.
 *        astSetCopy
@@ -347,7 +349,9 @@
 *        that may be associated with any Object as a scratch area for storing
 *        extra internal data.  May be useful to add to the public API later,
 *        though there is a danger there of users building ad-hoc data models
-*        around it; for now it is only intended for internal use.
+*        around it; for now it is only intended for internal use.  The
+*        companion astHasKeyMap method tests whether an Object already has an
+*        associated KeyMap without creating one.
 */
 
 /* Include files. */
@@ -1803,6 +1807,7 @@ struct AstKeyMap *astGetKeyMap_( AstObject *, int * );
 int astClassCompare_( AstObjectVtab *, AstObjectVtab *, int * );
 int astGetNobject_( const AstObject *, int * );
 int astGetRefCount_( AstObject *, int * );
+int astHasKeyMap_( AstObject *, int * );
 int astTestAttrib_( AstObject *, const char *, int * );
 int astTestID_( AstObject *, int * );
 int astTestIdent_( AstObject *, int * );
@@ -1979,6 +1984,7 @@ astINVOKE(V,astGetAttrib_(astCheckObject(this),attrib,STATUS_PTR))
 #define astGetID(this) astINVOKE(V,astGetID_(astCheckObject(this),STATUS_PTR))
 #define astGetIdent(this) astINVOKE(V,astGetIdent_(astCheckObject(this),STATUS_PTR))
 #define astGetKeyMap(this) astINVOKE(O,astGetKeyMap_(astCheckObject(this),STATUS_PTR))
+#define astHasKeyMap(this) astINVOKE(V,astHasKeyMap_(astCheckObject(this),STATUS_PTR))
 #define astGetNobject(this) astINVOKE(V,astGetNobject_(astCheckObject(this),STATUS_PTR))
 #define astClassCompare(class1,class2) astClassCompare_(class1,class2,STATUS_PTR)
 #define astGetRefCount(this) astINVOKE(V,astGetRefCount_(astCheckObject(this),STATUS_PTR))


### PR DESCRIPTION
Resolves #54.  My motivation here is primarily for use in yamlchan.c to make round-tripping certain transforms easier.

Currently it uses a lot of structural pattern-matching (e.g. `FindSphericalCartesian`) to reconstruct the appropriate ASDF transforms from a slice of the mapping list.  This code *is* still useful and necessary -- e.g. for hand-constructed astMapping, or one read from another source, one will still need to figure out the most appropriate way to serialize it back to ASDF.

But for the case of deserializing from ASDF it will also be very useful to maintain additional information on the deserialized mappings for accurate round-tripping without having to go down the full `Find<Foo>` path.  This idea is already used, to an extent, by the `KeyMap` attached to some mappings via `astSetProxy`, but that proves not as useful since the proxy object can't survive copying, per the discussion in #54.  So this would be used to replace that.

Had started out with trying to reorganize `ast_tester/testobject.c` in anticipation of adding more unit tests for this, but then realized since it's a protected interface it needs to be compiled with `astCLASS` defined, so ended up having to put the tests for this in a separate test program anyways.