### PR TITLE
Rebuild some fixtures that changed with the recent IsSimp clarification

### DIFF
--- a/ast_tester/rigby.simp
+++ b/ast_tester/rigby.simp
@@ -6,6 +6,7 @@
        Begin PermMap 	# Coordinate permutation
           Nin = 2 	# Number of input coordinates
           Nout = 3 	# Number of output coordinates
+          IsSimp = 1 	# Mapping has been simplified
        IsA Mapping 	# Mapping between coordinate systems
           Out1 = 1 	# Output coordinate 1 = input coordinate 1
           Out2 = -1 	# Output coordinate 2 = constant no. 1
@@ -23,6 +24,7 @@
           MapA = 	# First component Mapping
              Begin MatrixMap 	# Matrix transformation
                 Nin = 3 	# Number of input coordinates
+                IsSimp = 1 	# Mapping has been simplified
              IsA Mapping 	# Mapping between coordinate systems
                 M0 = 8.1296825791877598 	# Forward matrix value
                 M1 = 0.58230800408075301 	# Forward matrix value
@@ -52,6 +54,7 @@
                 MapA = 	# First component Mapping
                    Begin CmpMap 	# Compound Mapping
                       Nin = 3 	# Number of input coordinates
+                      IsSimp = 1 	# Mapping has been simplified
                    IsA Mapping 	# Mapping between coordinate systems
                       MapA = 	# First component Mapping
                          Begin WinMap 	# Map one window on to another
@@ -72,6 +75,7 @@
                             MapA = 	# First component Mapping
                                Begin CmpMap 	# Compound Mapping
                                   Nin = 2 	# Number of input coordinates
+                                  IsSimp = 1 	# Mapping has been simplified
                                IsA Mapping 	# Mapping between coordinate systems
                                   MapA = 	# First component Mapping
                                      Begin MatrixMap 	# Matrix transformation

--- a/ast_tester/simplify_fixtures/cap_matrixmap_03.simp
+++ b/ast_tester/simplify_fixtures/cap_matrixmap_03.simp
@@ -5,6 +5,7 @@
     MapA = 	# First component Mapping
        Begin ShiftMap 	# Shift each coordinate axis
           Nin = 2 	# Number of input coordinates
+          IsSimp = 1 	# Mapping has been simplified
        IsA Mapping 	# Mapping between coordinate systems
           Sft1 = -50.5 	# Shift for axis 1
           Sft2 = -50.5 	# Shift for axis 2

--- a/ast_tester/simplify_fixtures/cap_timemap_02.simp
+++ b/ast_tester/simplify_fixtures/cap_timemap_02.simp
@@ -215,11 +215,10 @@
     Ncoord = 1 	# Number of AstroCoords elements
     Coord1 = 	# AstroCoords number 1
        Begin KeyMap 	# Map of key/value pairs
-          KyCas = 1 	# Are keys case sensitive?
           MapSz = 16 	# Size of hash table
           MemCnt = 11 	# Total member count
-          Key1 = "Size" 	# Item name
-          Com1 = "AstroCoords size region" 	# Item comment
+          Key1 = "Error" 	# Item name
+          Com1 = "AstroCoords error region" 	# Item comment
           Typ1 = 4 	# Item data type (AST Object)
           Val1 = 	# Item value
              Begin Box 	# Axis intervals
@@ -427,8 +426,8 @@
                    End PointSet
              IsA Region 	# An area within a coordinate system
              End Box
-          Key4 = "Error" 	# Item name
-          Com4 = "AstroCoords error region" 	# Item comment
+          Key4 = "Size" 	# Item name
+          Com4 = "AstroCoords size region" 	# Item comment
           Typ4 = 4 	# Item data type (AST Object)
           Val4 = 	# Item value
              Begin Box 	# Axis intervals

--- a/ast_tester/simplify_fixtures/cap_winmap_03.simp
+++ b/ast_tester/simplify_fixtures/cap_winmap_03.simp
@@ -28,6 +28,7 @@
                 MapA = 	# First component Mapping
                    Begin ShiftMap 	# Shift each coordinate axis
                       Nin = 2 	# Number of input coordinates
+                      IsSimp = 1 	# Mapping has been simplified
                    IsA Mapping 	# Mapping between coordinate systems
                       Sft1 = 3.9331267401387842 	# Shift for axis 1
                       Sft2 = -1.0061396160665481e-16 	# Shift for axis 2
@@ -35,6 +36,7 @@
                 MapB = 	# Second component Mapping
                    Begin MatrixMap 	# Matrix transformation
                       Nin = 2 	# Number of input coordinates
+                      IsSimp = 1 	# Mapping has been simplified
                    IsA Mapping 	# Mapping between coordinate systems
                       M0 = 81.487330863050417 	# Forward matrix value
                       M1 = -81.487330863050417 	# Forward matrix value


### PR DESCRIPTION
The changes were not spotted in the test suite because these fixtures skip string compare and only use astEqual.